### PR TITLE
Require a skill to be set on the user profile before allowing a Protip.

### DIFF
--- a/app/controllers/protips_controller.rb
+++ b/app/controllers/protips_controller.rb
@@ -1,6 +1,7 @@
 class ProtipsController < ApplicationController
 
   before_filter :access_required, only: [:new, :create, :edit, :update, :destroy, :me]
+  before_filter :require_skills_first, only: [:new, :create]
   before_filter :lookup_protip, only: [:show, :edit, :update, :destroy, :upvote, :tag, :flag, :queue, :feature, :delete_tag]
   before_filter :reformat_tags, only: [:create, :update]
   before_filter :verify_ownership, only: [:edit, :update, :destroy]
@@ -555,5 +556,12 @@ class ProtipsController < ApplicationController
 
     topics = protips.map(&:tags).flatten.uniq.first(8) if topics.blank? && protips.present?
     topics
+  end
+
+  def require_skills_first
+    if current_user.skills.empty?
+      flash[:error] = "Please improve your profile by adding some skills before posting Pro Tips"
+      redirect_to badge_path(username: current_user.username, anchor: 'add-skill')
+    end
   end
 end

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -32,7 +32,7 @@
             = @user.protips.count > 1 ? 'Pro Tip'.pluralize : 'Pro Tip'
           .recent-pro-tip
             -if viewing_self?
-              %a.share-a-protip.track{:href => new_protip_path, 'data-action' => 'create protip', 'data-from' => 'profile card'}
+              %a.tip.share-a-protip.track{:href => new_protip_path, 'data-action' => 'create protip', 'data-from' => 'profile card', 'title' => @user.skills.empty? ? "Fill out your profile by adding some skills first, then share some Pro Tips!" : "Share your best coding tidbits!" }
                 Share a Pro Tip
             -else
               %h4 Most recent Protip

--- a/spec/controllers/protips_controller_spec.rb
+++ b/spec/controllers/protips_controller_spec.rb
@@ -34,9 +34,22 @@ describe ProtipsController do
   end
 
   describe "GET new" do
+    before { User.any_instance.stub(:skills).and_return(['skill']) } # User must have a skill to create protips
+
     it "assigns a new protip as @protip" do
       get :new, {}, valid_session
       assigns(:protip).should be_a_new(Protip)
+    end
+
+    it "allows viewing the page when you have a skill" do
+      get :new, {}, valid_session
+      response.should render_template('new')
+    end
+
+    it "prevents viewing the page when you don't have a skill" do
+      User.any_instance.stub(:skills).and_return([])
+      get :new, {}, valid_session
+      response.should redirect_to badge_path(username: current_user.username, anchor: 'add-skill')
     end
   end
 
@@ -49,6 +62,8 @@ describe ProtipsController do
   end
 
   describe "POST create" do
+    before { User.any_instance.stub(:skills).and_return(['skill']) } # User must have a skill to create protips
+
     describe "with valid params" do
       it "creates a new Protip" do
         expect {
@@ -82,6 +97,12 @@ describe ProtipsController do
         post :create, { protip: {} }, valid_session
         response.should render_template("new")
       end
+    end
+
+    it "prevents creating when you don't have a skill" do
+      User.any_instance.stub(:skills).and_return([])
+      post :create, {protip: valid_attributes}, valid_session
+      response.should redirect_to badge_path(username: current_user.username, anchor: 'add-skill')
     end
   end
 


### PR DESCRIPTION
Wip #45
https://assemblymade.com/coderwall/wips/45
