### PR TITLE
Remove cache directories from vagrant NFS sync

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -18,4 +18,9 @@ Badgiy::Application.configure do
   # Log the query plan for queries taking more than this (works
   # with SQLite, MySQL, and PostgreSQL)
   config.active_record.auto_explain_threshold_in_seconds = 0.5
+  
+  # Move cache dir's out of vagrant NFS directory
+  config.cache_store = [:file_store,"/tmp/codewall-cache/"]
+  config.assets.cache_store = [:file_store,"/tmp/codewall-cache/assets/"]
+  Rails.application.config.sass.cache_location = "/tmp/codewall-cache/sass/"
 end


### PR DESCRIPTION
Removes the cache directories from the main vagrant NFS sync directory in order to prevent errors like:

http://stackoverflow.com/questions/19124367/rails-app-on-percise32-vagrant-box-assets-get-text-file-busy-error-errnoe
