### PR TITLE
Fixed joining networks from networks list pages

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -211,6 +211,10 @@ h4 {
   }
 }
 
+.networks-header {
+  width: auto;
+}
+
 .secondary-notice {
   @include secondary-notice;
 }

--- a/app/views/networks/_alphabetized_list.html.haml
+++ b/app/views/networks/_alphabetized_list.html.haml
@@ -1,13 +1,11 @@
-
--cache ['v4', 'network_list', networks_list.count, params[:sort] || "unsorted", is_admin?, user.try(:id)], :expires_in => 1.day do
-  - networks = networks_list.sort_by(&:name)
-  - unless networks.blank?
-    - current_char = networks.first.name[0]
-    - alpha_networks = []
-    - networks.each do |network|
-      - if current_char != network.name[0]
-        = render :partial => "alpha_network", :locals => {:alphabet => current_char, :networks => alpha_networks}
-        - alpha_networks = []
-      - alpha_networks << network
-      - current_char = network.name[0]
-    = render :partial => "alpha_network", :locals => {:alphabet => current_char, :networks => alpha_networks}
+- networks = networks_list.sort_by(&:name)
+- unless networks.blank?
+  - current_char = networks.first.name[0]
+  - alpha_networks = []
+  - networks.each do |network|
+    - if current_char != network.name[0]
+      = render :partial => "alpha_network", :locals => {:alphabet => current_char, :networks => alpha_networks}
+      - alpha_networks = []
+    - alpha_networks << network
+    - current_char = network.name[0]
+  = render :partial => "alpha_network", :locals => {:alphabet => current_char, :networks => alpha_networks}

--- a/app/views/networks/_navigation.html.haml
+++ b/app/views/networks/_navigation.html.haml
@@ -1,4 +1,4 @@
-%header.cf.second-level-header
+%header.cf.second-level-header.networks-header
   -#%input.network-search(type='text' value='search networks')
   / %h1
   - unless network.nil?


### PR DESCRIPTION
WIP #39
https://assemblymade.com/coderwall/wips/39

Networks cannot be joined in production due to an improperly formed href value on the Join button/link.
- Removed improper caching from networks/_alphabetized_list partials.
- Also adjusted the width of the header for aesthetics on networks list pages

Caching of the _alphabetized_list partial would cache and display improper html that was inappropriate for logged in users vs non logged in users.  This causes joining a network to be broken currently for logged in users.

I have removed the caching entirely from the partial for 2 reasons:
- There are ~70 Networks at the moment, so caching is not entirely necessary at the moment.
- The controller action is pulling Network.all from cache anyways.  Caching the sorted partial seems overkill right now, especially considering it's breaking Join/Leave in production

I also took the opportunity to widen the navigation header in the Networks list pages, I think it looks better:

Before:
![networks-header](https://cloud.githubusercontent.com/assets/197892/3402344/e15c62c2-fd5a-11e3-9b23-db40e79ddaa5.png)

After:
![networks-full-width](https://cloud.githubusercontent.com/assets/197892/3402349/e6aacd2c-fd5a-11e3-947b-c50dc9f9cf67.png)
