### PR TITLE
Remove rails_stdout_logging in Gemfile 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -176,7 +176,6 @@ end
 
 group :production do
   gem 'honeybadger'
-  gem 'rails_stdout_logging'
   gem 'rails_12factor'
   gem 'unicorn'
   gem 'unicorn-worker-killer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -683,7 +683,6 @@ DEPENDENCIES
   rails-erd
   rails_12factor
   rails_autolink
-  rails_stdout_logging
   redcarpet
   redis
   resque


### PR DESCRIPTION
remove rails_stdout_logging gem as rails_12factor was made to include both 12factor gems which we already have included
