### PR TITLE
Moves hiding/showing the edit/delete/reply links to javascript function thats reusable across the application

### DIFF
--- a/app/assets/javascripts/protips.js.coffee
+++ b/app/assets/javascripts/protips.js.coffee
@@ -67,6 +67,7 @@ window.initializeProtip = ->
   fixScrollBars()
   fillComment()
   setupMobileMenu()
+  show_hide_by_current_user()
 
 toggleSubscriptionStatus = (subscription_link) ->
 #  subscription_link.toggleClass('protip-subscribe')

--- a/app/assets/stylesheets/protip.scss
+++ b/app/assets/stylesheets/protip.scss
@@ -453,11 +453,11 @@ body.protip-single {
           float: left;
           li {
             float: left;
-            margin-left: 10px;
-            padding-left: 10px;
-            border-left: solid 1px #777;
+            margin-right: 10px;
+            padding-right: 10px;
+            border-right: solid 1px #777;
 
-            &:first-child {
+            &:last-child {
               margin: 0;
               border: 0;
               padding: 0;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,9 +48,9 @@ class ApplicationController < ActionController::Base
 
   def viewing_user
     @viewing_user ||= current_user || begin
-    if cookies[:identity]
-      User.with_username(cookies[:identity])
-    end
+      if cookies[:identity]
+        User.with_username(cookies[:identity])
+      end
     end
   end
 

--- a/app/views/comments/_comment.html.haml
+++ b/app/views/comments/_comment.html.haml
@@ -17,15 +17,12 @@
           %input{:type => "button", :value => "Cancel", :class => "button cancel"}
   %ul.edit-del.cf
     - if signed_in?
-      - if can_edit_comment?(comment)
-        %li
-          %a.edit{:href => '#', :onclick => 'return false;'}
-            Edit
-        %li
-          %a.delete{:href => protip_comment_path(comment.commentable.try(:public_id), comment.id), 'data-method' => :delete}
-            Delete
-
-      -if !comment_author?(comment)
-        %li
-          %a.reply{:href => "#add-comment", :rel => "nofollow"}
-            Reply
+      %li.hidden.show-for-user{"data-user" => comment.user.username}
+        %a.edit{:href => '#', :onclick => 'return false;'}
+          Edit
+      %li.hidden.show-for-user{"data-user" => comment.user.username}
+        %a.delete{:href => protip_comment_path(comment.commentable.try(:public_id), comment.id), 'data-method' => :delete}
+          Delete
+      %li.remove-for-user{"data-user" => comment.user.username}
+        %a.reply{:href => "#add-comment", :rel => "nofollow"}
+          Reply

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -32,3 +32,4 @@
         = yield
     = render partial: 'shared/analytics'
     = render partial: 'shared/footer'
+    = render partial: 'shared/current_user_js'

--- a/app/views/layouts/protip.html.haml
+++ b/app/views/layouts/protip.html.haml
@@ -46,3 +46,5 @@
     = javascript_include_tag 'protips'
 
     = yield :javascript
+
+    = render partial: 'shared/current_user_js'

--- a/app/views/shared/_current_user_js.html.haml
+++ b/app/views/shared/_current_user_js.html.haml
@@ -1,0 +1,12 @@
+:javascript
+  window.current_user = "#{@current_user ? @current_user.username : "null"}";
+  function show_hide_by_current_user(){
+    if(window.current_user != null){
+      $('.show-for-user[data-user="' + window.current_user + '"').show();
+      $('.hide-for-user[data-user="' + window.current_user + '"').hide();
+      $('.remove-for-user[data-user="' + window.current_user + '"').remove();
+    }
+  }
+  $(function(){
+    show_hide_by_current_user();
+  })


### PR DESCRIPTION
Embeds username into a window variable, reuse across application to show/hide/remove dom content based on current_user.  Lets us cache these pages for logged in users and still render appropriate view.

Not 100% this is the best solution, but it works?
