### PR TITLE
Added the ability to override vagrant settings [skip ci]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ vagrant/coderwall-box/packer_virtualbox-iso_virtualbox.box
 vagrant/dotfiles
 vcr_cassettes
 erd.pdf
+vagrant.yml

--- a/vagrant.yml.example
+++ b/vagrant.yml.example
@@ -1,0 +1,16 @@
+# Custom Vagrant Settings [Example]
+# 
+# This file allows the override of Vagrant settings. 
+# In order to use, create a copy named vagrant.yml
+#
+
+virtualbox:
+  cpus: 4
+  memory: 4096
+network:
+  port_mappings:
+    rails: 3000
+    postgres: 2200
+    redis: 2201
+    elasticsearch: 9200
+    mongodb: 27017


### PR DESCRIPTION
As per discussion on Assembly, this pull request allows the settings in the Vagrantfile to be overriden without those changes populating to the general git repo. 

In otherwords, users can set their own ram, cpu, and more without changing the defaults.

[skip ci]
