### PR TITLE
Adjusted styles for sidebar featured team and created partial for markup separation.

### DIFF
--- a/app/assets/stylesheets/new-new-home.scss
+++ b/app/assets/stylesheets/new-new-home.scss
@@ -247,56 +247,71 @@
     }
   }
 }
-.team-box {
-  background: #fff;
-  color: #333;
-  display: block;
-  margin-bottom: 13%;
-  &:hover {
-    color: $light-blue;
-  }
-  .image-top {
-    position: relative;
-    img {
-      width: 100%;
-    }
-  }
-  .content {
-    padding: 0 8% 8% 8%;
+
+.featured-team {
+  .team-box {
     background: #fff;
-    z-index: 100;
-    .avatar {
+    color: #333;
+    display: block;
+    margin-bottom: 13%;
+    &:hover {
+      color: $light-blue;
+    }
+    .image-top {
       position: relative;
-      z-index: 100;
-      display: block;
-      margin-top: -24px;
-      margin-bottom: 1em;
-      width: 40px;
-      height: 40px;
-      @include border-radius(50%);
-      overflow: hidden;
-      background: #f7f7f7;
       img {
-        max-width: 100%;
+        width: 100%;
       }
     }
-    a {
-      text-decoration: none;
-      color: black;
-      &::selection {
+    .content {
+      padding: 0 8% 8% 8%;
+      background: #fff;
+      z-index: 100;
+      .avatar {
+        position: relative;
+        z-index: 100;
+        display: block;
+        margin-top: -24px;
+        margin-bottom: 1em;
+        width: 40px;
+        height: 40px;
+        @include border-radius(50%);
+        overflow: hidden;
+        background: #f7f7f7;
+        img {
+          max-width: 100%;
+        }
+      }
+      a {
+        text-decoration: none;
         color: black;
+        &::selection {
+          color: black;
+        }
       }
-    }
-    h4 {
-      text-transform: capitalize;
-      margin-bottom: 0.5em;
-    }
-    p {
-      font-size: 1.4em;
-      line-height: 1.6em;
+      h4 {
+        text-transform: capitalize;
+        margin-bottom: 0.5em;
+      }
+      p {
+        font-size: 1.4em;
+        line-height: 1.6em;
+      }
     }
   }
 }
+
+/* Override styles for featured team image if we're not using default image */
+
+.featured-team.custom-image {
+  .image-top {
+    padding: 8px;
+  }
+  .content .avatar {
+    margin-top: 1em;
+  }
+} 
+
 .tip-sidebar {
   width: 30%;
   float: right;

--- a/app/views/protips/_protip.html.haml
+++ b/app/views/protips/_protip.html.haml
@@ -66,23 +66,7 @@
                 = link_to '', report_inappropriate_protip_path(protip), method: :post, remote: true, class: (cookies["report_inappropriate-#{protip.public_id}"] ? 'user-flagged' : '') + ' user-flag'
 
           -if defined?(:job) && !job.nil?
-            %h3 Featured team
-            - adjective = ["is amazing", "is awesome", "has a great engineering team"].sample
-            =link_to teamname_path(job.team.slug), :class => 'team-box', 'data-action' => 'view team jobs', 'data-from' => 'job on protip', 'data-properties' => {"author's team" => protip.user.belongs_to_team?(job.team), 'adjective' => adjective, 'mode' => mode}.to_json do
-              .image-top
-                =image_tag(featured_team_banner(job.team))
-              .content
-                -#-team_member = protip.user.belongs_to_team?(job.team) ? protip.user : job.team.top_team_member
-                .avatar
-                  =image_tag(job.team.avatar_url)
-                %h4= job.team.name
-
-                %p
-                  ==Calling all #{job.title.pluralize}. #{job.team.name} #{adjective} and is hiring!
-            %a.feature-jobs.track{:href => employers_path, 'data-action' => 'upgrade team', 'data-from' => 'protip page'}
-              feature your jobs here
-
-            %pm:widget{"max-item-count" => "4", "show-thumbs" => "false", :title => "Recommended", :width => "244"}/
+            = render partial: "sidebar_featured_team", locals: {job: job, mode: mode, protip: protip}
 
     %article.tip-panel{:id => protip.public_id}
       -ab_test(TWITTER_SHARE_TEST, 'left', 'right') do |direction|

--- a/app/views/protips/_sidebar_featured_team.html.haml
+++ b/app/views/protips/_sidebar_featured_team.html.haml
@@ -1,0 +1,35 @@
+- # Locals params
+- # @param job [ Opportunity ]  - job needed to render this partial
+- # @param protip [ Protip ]    - protip page this job is being rendered on
+- # @param mode [ String ]      - page mode
+
+:ruby
+  team = job.team
+  adjective = ["is amazing", "is awesome", "has a great engineering team"].sample
+  team_has_featured_banner = team.featured_banner_image.present?
+  team_has_big_image = team.big_image.present?
+  team_has_custom_image = (team_has_featured_banner || team_has_big_image) ? true : false
+
+  banner_image = if team_has_featured_banner then team.featured_banner_image
+  elsif team_has_big_image then team.big_image
+  else default_featured_job_banner
+  end
+
+.featured-team{class: team_has_custom_image ? "custom-image" : "default-image"}
+  %h3 Featured team
+    
+  =link_to teamname_path(team.slug), class: 'team-box', 'data-action' => 'view team jobs', 'data-from' => 'job on protip', 'data-properties' => {"author's team" => protip.user.belongs_to_team?(team), 'adjective' => adjective, 'mode' => mode}.to_json do
+    .image-top
+      =image_tag(banner_image)
+    .content
+      -#-team_member = protip.user.belongs_to_team?(job.team) ? protip.user : job.team.top_team_member
+      .avatar
+        =image_tag(team.avatar_url)
+      %h4= team.name
+      %p
+        ==Calling all #{job.title.pluralize}. #{job.team.name} #{adjective} and is hiring!
+  %a.feature-jobs.track{href: employers_path, 'data-action' => 'upgrade team', 'data-from' => 'protip page'}
+    feature your jobs here
+
+  %pm:widget{"max-item-count" => "4", "show-thumbs" => "false", title: "Recommended", width: "244"}/
+}


### PR DESCRIPTION
Work for # 143
https://assembly.com/coderwall/wips/143

Markup and css has been adjusted to account for Featured Teams that have uploaded custom images to their Team profile:

Previous:
This is what the widget looked like previously.  Notice the avatar had negative margin which made it overlap the custom image.
![current](https://cloud.githubusercontent.com/assets/197892/3462624/7110f972-022f-11e4-87d0-11dd0ef24b44.png)

Updated:
This is what a featured team looks like with custom uploaded image:
![custom-image](https://cloud.githubusercontent.com/assets/197892/3462538/80c90f4a-022e-11e4-8547-c662ee3bcfc8.png)

No custom image:
This is what a featured team looks like without custom uploaded image:
![default-image](https://cloud.githubusercontent.com/assets/197892/3462530/677a3852-022e-11e4-9780-e4cd85a1aa13.png)
