### PR TITLE
Check if protip owner is banned before indexing.

### DIFF
--- a/app/jobs/index_protip.rb
+++ b/app/jobs/index_protip.rb
@@ -5,6 +5,6 @@ class IndexProtip < Struct.new(:protip_id)
 
   def perform
     protip = Protip.find(protip_id)
-    protip.tire.update_index
+    protip.tire.update_index unless protip.user.banned?
   end
 end


### PR DESCRIPTION
**Problem:** Banned user protips were making their way back into the search index somehow.

**Culprit:**
The search:sync task reindexes any protips that aren't found in the search index. https://github.com/assemblymade/coderwall/blob/master/lib/tasks/search.rake#L93-L95 
This had the effect of pulling in any protips that we had possibly deindexed on purpose (a user is banned).

**Solution:**
I chose the simplest method possible to ensure a user's tip is not reindexed again by adding the check to the IndexProtip job.  This will ensure that anytime we use the IndexProtip job, it accounts for a banned user.
