### PR TITLE
No longer linking @mentions that are in code blocks inside protips.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ vcr_cassettes
 erd.pdf
 vagrant.yml
 git_stats
+*.iml

--- a/lib/cfm.rb
+++ b/lib/cfm.rb
@@ -11,16 +11,20 @@ module CFM
         redcarpet.render(render_cfm(text)) unless text.nil?
       end
 
-      def render_cfm(text)
-        #hotlink coderwall usernames to their profile
-        text.gsub(/((?<!\s{4}).*)@([a-zA-Z_\-0-9]+)/) { $1+coderwall_user_link($2) }
-      end
-
       USERNAME_BLACKLIST = %w(include)
 
       private
+      def render_cfm(text)
+        text.lines.map { |x| inspect_line x }.join("\n")
+      end
+
       def coderwall_user_link(username)
         (User.where(username: username).exists? && !USERNAME_BLACKLIST.include?(username)) ? ActionController::Base.helpers.link_to("@#{username}", "/#{username}") : "@#{username}"
+      end
+
+      def inspect_line(line)
+        #hotlink coderwall usernames to their profile, but don't search for @mentions in code blocks
+        line.start_with?("    ") ? line : line.gsub(/((?<!\s{4}).*)@([a-zA-Z_\-0-9]+)/) { $1+coderwall_user_link($2) }
       end
     end
   end


### PR DESCRIPTION
Going through each individual line in the protip and only doing the username replacement if it doesn't start with four spaces (meaning it's a code block).
