### PR TITLE
Migrating data from mongo to postgres w/ mosql

### DIFF
--- a/collections.yml
+++ b/collections.yml
@@ -1,0 +1,41 @@
+badgify_development:
+  teams:
+    :columns:
+    - id:
+      :source: _id
+      :type: TEXT
+    - achievement_count: INTEGER
+    - analytics: BOOLEAN
+    - benefit_description_1: TEXT
+    - benefit_name_1: TEXT
+    - big_quote: TEXT
+    - blog_feed: TEXT
+    - created_at: timestamp without time zone
+    - endorsement_count: INTEGER
+    - featured_banner_image: TEXT
+    - headline: TEXT
+    - hide_from_featured: BOOLEAN
+    - hiring_tagline: TEXT
+    - mean: INTEGER
+    - median: INTEGER
+    - monthly_subscription: BOOLEAN
+    - name: TEXT
+    - number_of_jobs_to_show: INTEGER
+    - our_challenge: TEXT
+    - paid_job_posts: INTEGER
+    - premium: BOOLEAN
+    - reason_description_1: TEXT
+    - reason_name_1: TEXT
+    - reason_name_2: TEXT
+    - reason_name_3: TEXT
+    - score: INTEGER
+    - size: INTEGER
+    - slug: TEXT
+    - stack_list: TEXT
+    - total: INTEGER
+    - updated_at: timestamp without time zone
+    - valid_jobs: BOOLEAN
+    - your_impact: TEXT
+    :meta:
+      :table: teams
+      :extra_props: true


### PR DESCRIPTION
I've succeeded in setting up mosql to import the data from mongo to postgres.

I did a `gem install mosql` then `mosql -c collections.yml --sql postgres://localhost/coderwall_development --mongo mongodb://localhost`

In order for mosql to tail the oplog of mongo, it needs to be a replset, so it's not fully working locally. Before this is pushed to production, `badgify_development` will need to be change to whatever the database is called in production.

This will throw all arrays of data into an `_extra_props` field which we can pull out and parse as json, for now.
