### PR TITLE
WIP#189 Users have a link to to delete their account from the settings page

### DIFF
--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -88,6 +88,11 @@
               .setting
                 = form.label :api_key, 'API Key:'
                 = form.label @user.api_key
+            .left
+              .delete
+                %p
+                  Deleting your account is permanent and will make your username available to someone else. If you would still like to delete your account,
+                  = link_to "click here.", "/delete_account"
               .save=submit_tag 'Save', class: 'button'
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -386,7 +386,7 @@ Badgiy::Application.routes.draw do
 
   get 'award' => 'achievements#award', as: :award_badge
 
-  get '/auth/:provider/callback' => 'sessions#create', as: :authenticate
+  match '/auth/:provider/callback' => 'sessions#create', as: :authenticate
   get '/auth/failure' => 'sessions#failure', as: :authentication_failure
   get '/settings' => 'users#edit', as: :settings
   get '/redeem/:code' => 'redemptions#show'


### PR DESCRIPTION
Users have a link to to delete their account from the settings page. This takes them to another page where they can confirm that they actually want to delete their account.

The call out to delete your account could be a little more pronounced, but I wasn't use if that's something that should be boldly advertised. :smile:

I was having issues logging in to the developer provider with the route as get, so I changed it back to match. I'm open to changing that back if I can figure out how to login.
