### PR TITLE
Documenting how to start the server until we migrate to rails 4.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,7 @@ If you're running Windows, [here's a guide written by one of our members on how 
         cd ~/web
         rvm current # should be ruby-2.1.2@coderwall
         bundle check # should be 'The Gemfile's dependencies are satisfied'
-        bundle exec scripts/rails.rb server
+        bundle exec script/rails.rb server
 
     If all went well the Rails server should start up on PORT 3000.
 


### PR DESCRIPTION
I had some trouble starting rails and Mike mentioned that it had changed while we migrate to rails 4.

`bundle exec scripts/rails.rb server` is the new way to do it. I've just documented that in `CONTRIBUTING.md`
