### PR TITLE
Empty header to fix general styling issues for protip cards.

### DIFF
--- a/app/views/protips/_mini.html.haml
+++ b/app/views/protips/_mini.html.haml
@@ -1,7 +1,7 @@
 - protip = protip.load  #this is simply a hack, fix ES indexed json
 %article{:class => dom_class(protip), :id => protip.public_id}
-  -if display_protip_stats?(protip)  
-    %header
+  %header
+    -if display_protip_stats?(protip)
       %span{:class => protip_stat_class(protip)}
         = formatted_best_stat_value(protip) unless best_stat_name(protip) =~ /hawt/
 


### PR DESCRIPTION
This will fix the issue in general (and gets us back to the way it was previously).  The cards will now have extra padding at the top, and the title, author details on all cards should be aligned properly.

To do this well, I think we need to think about the UX of the card display and a better way to display the stats, title and author information.  Maybe I'll show some of my design chops and submit a mockup or two.
