### PR TITLE
Autosave all the protips - clientside of course. [WIP 146]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -746,7 +746,6 @@ DEPENDENCIES
   mongoid_taggable
   multi_json
   never_wastes
-  newrelic_rpm
   nokogiri
   octokit
   oj

--- a/app/assets/javascripts/autosaver.js.coffee
+++ b/app/assets/javascripts/autosaver.js.coffee
@@ -1,0 +1,71 @@
+window.Coderwall ?= {}
+window.Coderwall.Autosaver ?= {}
+
+class window.Coderwall.Autosaver.TextField
+
+  constructor: (options={}) ->
+    return unless @supportsStorage()
+
+    @autosave_field = $("##{options.field_id}")
+    @save_delay     = options.save_delay ? 3000
+    @storage_key    = options.storage_key ? "coderwall:autosaver:textfield:#{@autosave_field}"
+    @key_append     = options.storage_key_append
+    @storage_key    = "#{@storage_key}:#{@key_append}" if @key_append?
+    @initialize()
+    return
+
+
+  initialize: ()->
+    @populateOnInit()
+    @setupHandlers()
+    return
+
+
+  populateOnInit: ()->
+    if @fieldIsEmpty()
+      # attempt to populate from localstorage
+      data = @getStorage()
+      @autosave_field.val data if data?  
+    else
+      # prefill localstorage with content from field
+      @store @fieldValue()
+    return
+
+
+  setupHandlers: () ->
+    @autosave_field.on "keyup", (e)=>
+      unless @save_timeout?
+        @save_timeout = setTimeout @saveTimeoutHandler, @save_delay
+    return
+
+
+  supportsStorage: ()->
+    window.localStorage?
+
+
+  store: (value)->
+    localStorage.setItem @storageKey(), JSON.stringify(value)
+    return
+
+
+  getStorage: ()->
+    JSON.parse localStorage.getItem(@storageKey())
+
+
+  storageKey: ()->
+    @storage_key
+
+
+  saveTimeoutHandler: ()=>
+    @store @fieldValue()
+    delete @save_timeout
+
+  clear: ()->
+    clearTimeout(@save_timeout)
+    delete localStorage[@storageKey()]
+
+  fieldIsEmpty: ()->
+    @fieldValue() == ""
+
+  fieldValue: ()->
+    @autosave_field.val()

--- a/app/assets/javascripts/protips.js.coffee
+++ b/app/assets/javascripts/protips.js.coffee
@@ -36,6 +36,7 @@ window.initializeProtip = ->
   if inEditMode = $(".x-tip-content.preview").length > 0
     setTimeout (->
       animateFloat()), 100
+    registerAutosaver()
     registerTextareaAutoResize()
     registerFlipper()
     enableDragNDrop()
@@ -142,6 +143,11 @@ fetchPreview = ->
         topics: topics
     success: (data, status, xhr) ->
       preview(data)
+
+registerAutosaver = ->
+  window.protip_auto_saver = new Coderwall.Autosaver.TextField({field_id: "protip_body", key_append: window.current_user})
+  $("#protip-save-and-publish-button").on "click" , ()->
+    window.protip_auto_saver.clear()
 
 registerTextareaAutoResize = ->
   $("textarea").keydown (event) ->

--- a/app/views/layouts/protip.html.haml
+++ b/app/views/layouts/protip.html.haml
@@ -43,7 +43,7 @@
     = render partial: 'shared/mixpanel_properties'
     = javascript_include_tag 'highlight/highlight.js'
     = javascript_include_tag 'highlight/language.js'
-
+    = javascript_include_tag 'autosaver.js'
     = javascript_include_tag 'protips'
 
     = yield :javascript

--- a/app/views/protips/_new_or_edit.html.haml
+++ b/app/views/protips/_new_or_edit.html.haml
@@ -37,4 +37,4 @@
 
       .vertical-floatable
         = p.button :submit, 'Preview or cmd +', class: "preview-button"
-        = p.submit 'Save & Publish', class: "save-and-publish"
+        = p.submit 'Save & Publish', class: "save-and-publish",id: "protip-save-and-publish-button"

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,5 +1,6 @@
 Coderwall::Application.configure do
   config.assets.precompile << /\.(?:svg|eot|woff|ttf)$/
   config.assets.precompile << 'admin.css'
+  config.assets.precompile << 'autosaver.js'
   config.assets.version = '1.1'
 end


### PR DESCRIPTION
Work for WIP #146 - https://assembly.com/coderwall/wips/146

Current behavior:
- Once a user starts typing, we save the Protip text area content every 3 seconds.  Delay can be configured if we want.
- If content has been saved, and a user navigates away from the page (or has a browser crash, etc) - when they come back to the new Protip form, their autosaved content will be populated in the text area from localStorage.
- When a user submits the form successfully, the autosaved text area content is cleared.  The next request to the new Protip form will not populate the text area with any localStorage content.
- When a user submits the form unsuccessfully (validation errors) the form will maintain it's field content from the form submission and store the prefilled text area content into localStorage.
