### PR TITLE
Proper ember template paths

### DIFF
--- a/app/assets/javascripts/ember/views/events/achievement.js.coffee
+++ b/app/assets/javascripts/ember/views/events/achievement.js.coffee
@@ -1,5 +1,5 @@
 Coderwall.AchievementEventView = Ember.View.extend(
-  templateName: "ember/templates/events/achievement"
+  templateName: "events/achievement"
   eventBinding: 'content'
   tagName: "li"
   classNameBindings: ["protipEvent"]

--- a/app/assets/javascripts/ember/views/events/activity_feed.js.coffee
+++ b/app/assets/javascripts/ember/views/events/activity_feed.js.coffee
@@ -1,5 +1,5 @@
 Coderwall.ActivityListView = Ember.CollectionView.create(
-#  templateName: "ember/templates/events/activity_list"
+#  templateName: "events/activity_list"
   contentBinding: "Coderwall.activityFeedController.activities"
   tagName: "ul"
   createChildView: (view, attrs) ->
@@ -35,7 +35,7 @@ Coderwall.ActivityListView = Ember.CollectionView.create(
 )
 
 Coderwall.MoreActivityView = Ember.View.create(
-  #templateName: "ember/templates/events/more_activity"
+  #templateName: "events/more_activity"
   classNameBindings: ["visibility"]
   tagName: "li"
 
@@ -60,7 +60,7 @@ Coderwall.ActivityFeedView = Ember.ContainerView.create(
 )
 
 Coderwall.ActivityStatsView = Ember.View.create(
-  #templateName: "ember/templates/events/stats"
+  #templateName: "events/stats"
   tagName: "ul"
   profileViewsBinding: "Coderwall.statsController.profileViews"
   followersBinding: "Coderwall.statsController.followers"

--- a/app/assets/javascripts/ember/views/events/admin.js.coffee
+++ b/app/assets/javascripts/ember/views/events/admin.js.coffee
@@ -1,5 +1,5 @@
 Coderwall.AdminEventView = Ember.View.extend(
-  templateName: "ember/templates/events/admin"
+  templateName: "events/admin"
   eventBinding: 'content'
   tagName: "li"
   classNameBindings: ["protipEvent"]

--- a/app/assets/javascripts/ember/views/events/comment.js.coffee
+++ b/app/assets/javascripts/ember/views/events/comment.js.coffee
@@ -1,5 +1,5 @@
 Coderwall.CommentEventView = Ember.View.extend(
-  templateName: "ember/templates/events/comment"
+  templateName: "events/comment"
   eventBinding: 'content'
   tagName: "li"
   classNameBindings: ["commentEvent"]

--- a/app/assets/javascripts/ember/views/events/endorsement.js.coffee
+++ b/app/assets/javascripts/ember/views/events/endorsement.js.coffee
@@ -1,5 +1,5 @@
 Coderwall.EndorsementEventView = Ember.View.extend(
-  templateName: "ember/templates/events/endorsement"
+  templateName: "events/endorsement"
   eventBinding: 'content'
   tagName: "li"
   classNameBindings: ["endorsementEvent"]

--- a/app/assets/javascripts/ember/views/events/event.js.coffee
+++ b/app/assets/javascripts/ember/views/events/event.js.coffee
@@ -1,5 +1,5 @@
 Coderwall.EventView = Ember.View.extend(
-  templateName: "ember/templates/events/activity_list"
+  templateName: "events/activity_list"
   activityBinding: "Coderwall.activityFeedController.activities"
 
 )

--- a/app/assets/javascripts/ember/views/events/expert.js.coffee
+++ b/app/assets/javascripts/ember/views/events/expert.js.coffee
@@ -1,5 +1,5 @@
 Coderwall.ExpertEventView = Ember.View.extend(
-  templateName: "ember/templates/events/expert"
+  templateName: "events/expert"
   eventBinding: 'content'
   tagName: "li"
   classNameBindings: ["expertEvent"]

--- a/app/assets/javascripts/ember/views/events/follow.js.coffee
+++ b/app/assets/javascripts/ember/views/events/follow.js.coffee
@@ -1,5 +1,5 @@
 Coderwall.FollowEventView = Ember.View.extend(
-  templateName: "ember/templates/events/follow"
+  templateName: "events/follow"
   eventBinding: 'content'
   tagName: "li"
   classNameBindings: ["followEvent"]

--- a/app/assets/javascripts/ember/views/events/protip.js.coffee
+++ b/app/assets/javascripts/ember/views/events/protip.js.coffee
@@ -1,5 +1,5 @@
 Coderwall.ProtipEventView = Ember.View.extend(
-  templateName: "ember/templates/events/protip"
+  templateName: "events/protip"
   eventBinding: 'content'
   tagName: "li"
   classNameBindings: ["protipEvent"]

--- a/app/assets/javascripts/ember/views/events/skill.js.coffee
+++ b/app/assets/javascripts/ember/views/events/skill.js.coffee
@@ -1,5 +1,5 @@
 Coderwall.SkillEventView = Ember.View.extend(
-  templateName: "ember/templates/events/skill"
+  templateName: "events/skill"
   eventBinding: 'content'
   tagName: "li"
   classNameBindings: ["protipEvent"]

--- a/app/assets/javascripts/ember/views/events/team.js.coffee
+++ b/app/assets/javascripts/ember/views/events/team.js.coffee
@@ -1,5 +1,5 @@
 Coderwall.TeamEventView = Ember.View.extend(
-  templateName: "ember/templates/events/team"
+  templateName: "events/team"
   eventBinding: 'content'
   tagName: "li"
   classNameBindings: ["protipEvent"]

--- a/app/assets/javascripts/ember/views/events/view.js.coffee
+++ b/app/assets/javascripts/ember/views/events/view.js.coffee
@@ -1,5 +1,5 @@
 Coderwall.ViewEventView = Ember.View.extend(
-  templateName: "ember/templates/events/view"
+  templateName: "events/view"
   eventBinding: 'content'
   tagName: "li"
   classNameBindings: ["protipEvent"]

--- a/app/assets/javascripts/ember/views/networks/network.js.coffee
+++ b/app/assets/javascripts/ember/views/networks/network.js.coffee
@@ -7,7 +7,7 @@ Coderwall.AllNetworksView = Ember.View.create(
 
   templateName: (->
     templateName = if @get('sortOrder')? then @get('sortOrder') else "a_z"
-    "ember/templates/networks/all_networks/" + templateName
+    "networks/all_networks/" + templateName
   ).property("sortOrder").cacheable()
 
   sortByAlpyhabet: ->

--- a/app/assets/javascripts/ember/views/teams/index.js.coffee
+++ b/app/assets/javascripts/ember/views/teams/index.js.coffee
@@ -1,5 +1,5 @@
 Coderwall.ListTeamsView = Ember.View.extend(
-  templateName: "ember/templates/teams/index"
+  templateName: "teams/index"
   teamsBinding: "Coderwall.teamsController"
 
   refreshListing: ->

--- a/app/assets/javascripts/ember/views/teams/show.js.coffee
+++ b/app/assets/javascripts/ember/views/teams/show.js.coffee
@@ -1,5 +1,5 @@
 Coderwall.ShowTeamView = Ember.View.extend(
-  templateName: "ember/templates/teams/show"
+  templateName: "teams/show"
   classNames: [ "team" ]
   tagName: "tr"
 


### PR DESCRIPTION
I believe this should fix the Ember template issue found in the second screenshot here (https://assembly.com/coderwall/wips/318).

In production, ember templates are stored at Ember.TEMPLATES.  Using console, and executing:
`Ember.TEMPLATES["ember/templates/events/view"] -> undefined`
`Ember.TEMPLATES["events/view"] -> function (n,i){return i=i||{},t.call(r,e,n,i.helpers,i.partials,i.data)}`

This is a bit hairy at the moment to test properly on a local server.  Requires running rails in production mode, which is not a simple matter.  Having at least a staging application running a production environment would be helpful for work like this and to just have a general sanity/review process for deployment.
