### PR TITLE
Stop updating user team id on Mongoid exception.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -218,9 +218,11 @@ class User < ActiveRecord::Base
   def team
     @team ||= team_document_id && Team.find(team_document_id)
   rescue Mongoid::Errors::DocumentNotFound
-    #readonly issue in follows/_user partial from partial iterator
-    User.connection.execute("UPDATE users set team_document_id = NULL where id = #{self.id}")
+    Rails.logger.error("[Mongoid::Errors::DocumentNotFound] - Couldn't find Team using #{team_document_id} for user: #{id}")
     @team = nil
+    #readonly issue in follows/_user partial from partial iterator
+    #User.connection.execute("UPDATE users set team_document_id = NULL where id = #{self.id}")
+    #@team = nil
   end
 
   def on_premium_team?


### PR DESCRIPTION
Submitting this change so that we stop updating the team_document_id on Mongoid error and we log the error.  This will hopefully help to give us insight to what users / teams this is happening to so we can fix this issue.
