### PR TITLE
Lookup user by id, not username - fixes AR::RecordNotFound [WIP-334]

### DIFF
--- a/app/workers/user_activate_worker.rb
+++ b/app/workers/user_activate_worker.rb
@@ -6,7 +6,7 @@ class UserActivateWorker
     user = User.find(user_id)
     return if user.active?
 
-    RefreshUserJob.new.perform(user.username)
+    RefreshUserJob.new.perform(user.id)
     NotifierMailer.welcome_email(user.username).deliver
 
     user.activate!

--- a/spec/workers/user_activate_worker_spec.rb
+++ b/spec/workers/user_activate_worker_spec.rb
@@ -22,6 +22,19 @@ RSpec.describe UserActivateWorker do
         expect(user.active?).to eq(true)
         expect(user.activated_on).not_to eq(nil)
       end
+
+      it "should send welcome mail" do
+        mail = double("mail")
+        expect(NotifierMailer).to receive(:welcome_email).with(user.username).and_return(mail)
+        expect(mail).to receive(:deliver)
+        worker.perform(user.id)
+      end
+
+      it "should create refresh job" do
+        expect_any_instance_of(RefreshUserJob).to receive(:perform).with(user.id)
+        worker.perform(user.id)
+      end
+
     end
 
     context 'when activate user' do


### PR DESCRIPTION
Fixes: https://assembly.com/coderwall/wips/334

RefreshUserJob performs a lookup by user_id rather than username.  `line 8: user = User.find(user_id)`

Errors in production were averaging 6% and spiking to 12%.  This should fix a majority of those errors.
