### PR TITLE
fix #304: Previewing a protip in firefox doesn't hide back of the card

### DIFF
--- a/app/assets/stylesheets/protip.css.scss
+++ b/app/assets/stylesheets/protip.css.scss
@@ -1341,6 +1341,10 @@ body.protip-single {
 
     &.rotated {
       @include rotateY(180deg);
+      // fix #304: Previewing a protip in firefox doesn't hide back of the card
+      .front{
+        display: none;
+      }
     }
   }
 }


### PR DESCRIPTION
FIY: https://assembly.com/coderwall/wips/304
