### PR TITLE
Fix the Assembly banner text

### DIFF
--- a/app/views/shared/_assembly_banner.html.erb
+++ b/app/views/shared/_assembly_banner.html.erb
@@ -4,7 +4,7 @@
       <div class="announcement col-md-12">
         <p class="text-center">
           <img src="https://treasure.assembly.com/assets/brand/inverse@2x.png" class="asm-brand">
-          Coderwall is an open product on Assembly so now you can help build it!
+          Coderwall is an open product on Assembly &mdash; now you can help build it!
           <a href="https://assembly.com/coderwall/chat" target="_blank"> Jump in and get started.</a>
           <a class="js-dismiss close" href="#close">x</a>
         </p>


### PR DESCRIPTION
I added an em-dash and removed "so" so that the text reads better.
