### PR TITLE
Improve page loading time for the Protips page #371

### DIFF
--- a/app/controllers/protips_controller.rb
+++ b/app/controllers/protips_controller.rb
@@ -424,7 +424,8 @@ class ProtipsController < ApplicationController
 
     {
       page:     (signed_in? && search_options_params[:page].try(:to_i)) || 1,
-      per_page: [(signed_in? && search_options_params[:per_page].try(:to_i)) || 18, Protip::PAGESIZE].min
+      per_page: [(signed_in? && search_options_params[:per_page].try(:to_i)) || 18, Protip::PAGESIZE].min,
+      load: { include: [:user, :likes, :protip_links, :comments] }
     }
   end
 

--- a/app/models/protip.rb
+++ b/app/models/protip.rb
@@ -551,7 +551,7 @@ class Protip < ActiveRecord::Base
     {
       views:    self.total_views/COUNTABLE_VIEWS_CHUNK,
       upvotes:  self.upvotes,
-      comments: self.comments.count,
+      comments: self.comments.size,
       hawt:     self.hawt? ? 100 : 0
     }.sort_by do |k, v|
       -v
@@ -559,7 +559,7 @@ class Protip < ActiveRecord::Base
   end
 
   def upvotes
-    @upvotes ||= likes.count
+    likes.size
   end
 
   def upvotes=(count)
@@ -782,7 +782,7 @@ class Protip < ActiveRecord::Base
     if self.new_record?
       self.links.select { |link| ProtipLink.is_image? link }
     else
-      protip_links.where('kind in (?)', ProtipLink::IMAGE_KINDS).map(&:url)
+      protip_links.loaded? ? protip_links.select { |p| ProtipLink::IMAGE_KINDS.include?(p.kind.to_sym) }.map(&:url) : protip_links.where('kind in (?)', ProtipLink::IMAGE_KINDS).map(&:url)
     end
   end
 

--- a/app/views/protips/_grid.html.haml
+++ b/app/views/protips/_grid.html.haml
@@ -21,7 +21,7 @@
       - if protip == 'show-ad'
         = render(partial: 'opportunities/mini', locals: { opportunity: opportunity })
       -elsif protip.present?
-        - if protip = protip.load rescue nil # HACK: User deleted, protip no longer exists. Won't be found.
+        - if protip.is_a?(Protip) || protip = protip.load rescue nil # HACK: User deleted, protip no longer exists. Won't be found.
           %li{ class: (protip.kind == 'link' ? 'ext-link' : '') }
             = render(partial: 'protips/mini', locals: { protip: protip, mode: mode })
 


### PR DESCRIPTION
Adding eager loading of Protip search results to minimize the number of sql queries during page rendering.

Some mini-profiler data:
Profiling Before

```
GET http://localhost:3000/  1469.5  2881.1  +0.0    1 sql   0.4
  Executing action: index   67.7    1411.6  +1468.0 13 sql  7.7
   Net::HTTP POST /track/   97.8    97.8    +1500.0 
   Net::HTTP GET /opportunities/opportunity/_sea... 2.1 2.1 +1605.0 
   Rendering: protips/index 40.8    1116.0  +1631.0 7 sql   4.5
    Rendering: protips/_grid    380.7   1075.2  +1672.0 44 sql  19.0
     Rendering: protips/_mini   45.0    45.0    +1701.0 8 sql   5.7
     Rendering: protips/_mini   27.5    27.5    +1769.0 6 sql   3.3
     Rendering: protips/_mini   27.0    27.0    +1816.0 5 sql   2.8
     Rendering: protips/_mini   28.4    28.4    +1862.0 5 sql   2.5
     Rendering: protips/_mini   25.4    25.4    +1917.0 5 sql   2.8
     Rendering: protips/_mini   105.8   105.8   +1965.0 5 sql   2.7
     Rendering: protips/_mini   35.0    35.0    +2088.0 5 sql   2.9
     Rendering: protips/_mini   24.8    24.8    +2148.0 5 sql   2.5
     Rendering: protips/_mini   28.7    28.7    +2189.0 5 sql   2.8
     Rendering: protips/_mini   25.5    25.5    +2235.0 5 sql   3.0
     Rendering: protips/_mini   25.3    25.3    +2277.0 5 sql   2.5
     Rendering: protips/_mini   25.3    25.3    +2320.0 5 sql   2.3
     Rendering: protips/_mini   23.9    23.9    +2366.0 5 sql   2.4
     Rendering: protips/_mini   32.2    32.2    +2410.0 5 sql   2.6
     Rendering: protips/_mini   33.0    33.0    +2461.0 5 sql   2.6
     Rendering: protips/_mini   33.0    33.0    +2513.0 5 sql   2.6
     Rendering: protips/_mini   107.2   107.2   +2572.0 5 sql   4.6
     Rendering: protips/_mini   41.4    41.4    +2705.0 5 sql   5.2
   Rendering: layouts/application   71.9    128.1   +2747.0 
    Rendering: application/_nav_bar 20.0    21.2    +2781.0 
    Rendering: shared/_footer   12.8    34.6    +2828.0 
     Rendering: shared/_mixpanel_properties 21.8    21.8    +2841.0 7 sql   3.7
```

Profiling After

```
GET http://localhost:3000/  1471.6  2350.0  +0.0    1 sql   0.4
  Executing action: index   117.2   878.4   +1471.0 20 sql  17.0
   Net::HTTP POST /track/   108.3   108.3   +1505.0 
   Net::HTTP GET /opportunities/opportunity/_sea... 2.7 2.7 +1667.0 
   Rendering: protips/index 35.2    527.4   +1695.0 7 sql   4.3
    Rendering: protips/_grid    237.0   492.1   +1730.0 
     Rendering: protips/_mini   19.8    19.8    +1741.0 2 sql   1.3
     Rendering: protips/_mini   10.3    10.3    +1772.0 1 sql   0.6
     Rendering: protips/_mini   7.4 7.4 +1802.0 
     Rendering: protips/_mini   8.0 8.0 +1825.0 
     Rendering: protips/_mini   8.1 8.1 +1844.0 
     Rendering: protips/_mini   16.9    16.9    +1865.0 
     Rendering: protips/_mini   8.0 8.0 +1897.0 
     Rendering: protips/_mini   9.0 9.0 +1918.0 
     Rendering: protips/_mini   62.6    62.6    +1939.0 
     Rendering: protips/_mini   15.7    15.7    +2013.0 
     Rendering: protips/_mini   10.1    10.1    +2046.0 
     Rendering: protips/_mini   8.9 8.9 +2073.0 
     Rendering: protips/_mini   8.4 8.4 +2093.0 
     Rendering: protips/_mini   12.7    12.7    +2113.0 
     Rendering: protips/_mini   12.0    12.0    +2137.0 
     Rendering: protips/_mini   12.1    12.1    +2160.0 
     Rendering: protips/_mini   12.9    12.9    +2184.0 
     Rendering: protips/_mini   12.4    12.4    +2209.0 
   Rendering: layouts/application   69.8    122.9   +2222.0 
    Rendering: application/_nav_bar 18.5    19.3    +2258.0 
    Rendering: shared/_footer   13.2    33.1    +2301.0 
     Rendering: shared/_mixpanel_properties 19.9    19.9    +2313.0 7 sql   3.7
    Rendering: shared/_footer   19.9    47.7    +2439.0 
     Rendering: shared/_mixpanel_properties 27.7    27.7    +2459.0 7 sql   3.8
```
