### PR TITLE
#408 Adding heroku_deflater gem to append gzipped asset locations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -184,4 +184,5 @@ group :production do
   gem 'newrelic_rpm'
   gem 'puma'
   gem 'rails_12factor'
+  gem 'heroku-deflater'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -304,6 +304,8 @@ GEM
     handlebars-source (1.3.0)
     hashie (2.1.2)
     hashr (0.0.22)
+    heroku-deflater (0.5.3)
+      rack (>= 1.4.5)
     highline (1.6.21)
     hike (1.2.3)
     hirb (0.7.2)
@@ -749,6 +751,7 @@ DEPENDENCIES
   hamlbars
   handlebars-source
   hashie
+  heroku-deflater
   jazz_hands!
   jbuilder
   jquery-rails (= 2.0.3)


### PR DESCRIPTION
More information here:
http://thediscoblog.com/blog/2013/05/01/the-rails-cloudfront-and-heroku-performance-hat-trick/

And here:
https://github.com/romanbsd/heroku-deflater
