### PR TITLE
Add instructions for creating Stripe plans

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,6 +174,8 @@ If you're running Windows, [here's a guide written by one of our members on how 
 
 You'll need to set up a test account with Stripe for local development until this dependency is refactored out of development/test.
 
+See [docs/configuration.md](https://github.com/assemblymade/coderwall/blob/master/docs/configuration.md#stripe) for more.
+
 ## Github configuration
 
 You will need a Github application configured for local development until this dependency is refactored out of development/test.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,11 +15,9 @@ GITHUB_SECRET
 
 ### Stripe
 A stripe testing account may be freely signed up for over at [dashboard.stripe.com/register](https://dashboard.stripe.com/register). By default your account will be set to testing mode, unless you choice to activate it. Once your account is created your going to want to create the following plans to match what coderwall currently provides, as defined below. Finally [dashboard.stripe.com/account/apikeys](https://dashboard.stripe.com/account/apikeys) will provide test keys for you to use.
-```
-# TODO: Provide Plan Details
-```
 
-```
-STRIPE_PUBLISHABLE_KEY
-STRIPE_SECRET_KEY
-```
+Set your `STRIPE_PUBLISHABLE_KEY` and `STRIPE_SECRET_KEY` in the `.env` file. 
+
+You will also need to create the recurring billing plans on Stripe. You can do this by hand (e.g. in the Stripe admin dashboard), or via the rails console. Use `vagrant ssh` to connect to the Rails console, and issue the following command:
+
+`Plan.all.each { |p| p.register_on_stripe }`


### PR DESCRIPTION
I had trouble getting Stripe to work in development following the "[getting started](https://www.youtube.com/watch?v=6xXOfQFj98g&index=4&list=PLhlPwpqjsgvXK4n8FJBbj7KkvuOw8h3FO)" Youtube video.

It turns out you have to create the plans on your own Stripe account manually.

This PR updates the documentation to reflect this.
