### PR TITLE
Bug delete user #398

### DIFF
--- a/spec/features/helpers/general_helpers.rb
+++ b/spec/features/helpers/general_helpers.rb
@@ -24,6 +24,8 @@ module Features
         fill_in 'user_location', with: settings[:location]
         click_button 'Finish'
       end
+
+      user
     end
 
     def create_team(name = 'TEST_TEAM')

--- a/spec/features/users/user_management_spec.rb
+++ b/spec/features/users/user_management_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+feature "User management", js: true do
+  describe 'deleting a user' do
+    before do
+      stub_request(:post, /api.mixpanel.com/)
+    end
+
+    let!(:user) { login_as(username: 'alice', bypass_ui_login: true) }
+
+    scenario 'user is presented with confirmation dialog when deletes his account' do
+      visit '/settings'
+      find('.delete').click_link 'click here.'
+
+      expect(page).to have_content 'Warning: clicking this link below will permenatly delete your Coderwall account and its data.'
+      expect(page).to have_button 'Delete your account & sign out'
+    end
+
+    scenario 'user is redirected to /welcome after deleting hios account' do
+      visit '/settings'
+      find('.delete').click_link 'click here.'
+      find('.save').click_button 'Delete your account & sign out'
+
+      expect(current_path).to eq('/welcome')
+    end
+
+    scenario 'user cannot login after deleting his account' do
+      visit '/settings'
+      find('.delete').click_link 'click here.'
+      find('.save').click_button 'Delete your account & sign out'
+
+      visit "/auth/developer"
+      fill_in 'name', with: user.username
+      fill_in 'email', with: user.email
+      click_button 'Sign In'
+
+      expect(current_path).to eq(new_user_path)
+    end
+
+    scenario 'users protips are not displayed after he deletes his account' do
+      Protip.rebuild_index
+      protip_1, protip_2 = Fabricate.times(2, :protip, user: user)
+      protip_3 = Fabricate(:protip)
+
+      visit '/settings'
+      find('.delete').click_link 'click here.'
+      find('.save').click_button 'Delete your account & sign out'
+
+      login_as(username: 'bob', bypass_ui_login: true)
+      visit '/p/fresh'
+
+      expect(page).not_to have_content(protip_1.title)
+      expect(page).not_to have_content(protip_2.title)
+      expect(page).to have_content(protip_3.title)
+    end
+  end
+
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -329,7 +329,16 @@ RSpec.describe User, :type => :model do
     it "should not default to banned" do
       expect(user.banned?).to eq(false)
     end
+ end
 
+  describe 'deleting a user', focus: true do
+    it 'deletes asosciated prtotips' do
+      user = Fabricate(:user)
+      protip = Fabricate(:protip, user: user)
+
+      expect(user.reload.protips).to receive(:destroy_all).and_return(false)
+      user.destroy
+    end
   end
 
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe "User management", :type => :request do
+
+  describe 'deleting a user' do
+    it 'deletes associated protips and reindex search index' do
+      user = Fabricate(:user)
+
+      Protip.rebuild_index
+      protip_1, protip_2 = Fabricate.times(2, :protip, user: user)
+      protip_3 = Fabricate(:protip)
+
+      user.reload.destroy
+      search = Protip.search('*').map(&:title)
+
+      expect(search).not_to include(protip_1.title)
+      expect(search).not_to include(protip_2.title)
+      expect(search).to include(protip_3.title)
+    end
+  end
+
+end


### PR DESCRIPTION
Bounty: [BUG: After deleting a user/protip Coderwall will generate a 404 on the logged in home](https://assembly.com/coderwall/bounties/398)

Simple fix, but took ages to figure out.

For some reason (please somebody tell me why) `has_many :protips, dependent: delete_all` deletes all protips associated with a user, but does not trigger `after_destroy` or any other callbacks of `Protip`. 
(hence does not update the ES index, deleted Protip's ids get returned in search results....eventually that causes `ActiveRecord::NoRecordFound` and 404)

I have tried `dependent: :destroy, destroy_all` - no effect, so just added a `before_destroy` callback for the User model.
