### PR TITLE
Add Google's sitelinks search box support #415

### DIFF
--- a/app/views/layouts/home4-layout.html.haml
+++ b/app/views/layouts/home4-layout.html.haml
@@ -9,6 +9,7 @@
     %meta{ name: 'google', value: 'notranslate' }
     = render partial: 'shared/analytics'
     = render partial: 'shared/mixpanel'
+    = render partial: 'shared/schema.org'
 
     %meta{ name: 'twitter:account_id', content: ENV['TWITTER_ACCOUNT_ID'] }
     = metamagic

--- a/app/views/shared/_schema.org.html.erb
+++ b/app/views/shared/_schema.org.html.erb
@@ -1,0 +1,14 @@
+<!-- schema.org markup for Google Search integration (https://developers.google.com/webmasters/richsnippets/sitelinkssearch?utm_source=wmc-blog&utm_medium=direct-referral&utm_campaign=sitelinks-searchbox) -->
+
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "WebSite",
+  "url": "<%= root_url %>",
+  "potentialAction": {
+    "@type": "SearchAction",
+    "target": "<%= raw search_protips_url(scope: "everything") %>&search={search_term_string}",
+    "query-input": "required name=search_term_string"
+  }
+}
+</script>


### PR DESCRIPTION
Add schema.org markup as specified at: https://developers.google.com/webmasters/richsnippets/sitelinkssearch?utm_source=wmc-blog&utm_medium=direct-referral&utm_campaign=sitelinks-searchbox
