### PR TITLE
Split up Sidekiq work across more specific queues. #422

### DIFF
--- a/app/jobs/analyze_spam_job.rb
+++ b/app/jobs/analyze_spam_job.rb
@@ -1,7 +1,7 @@
 class AnalyzeSpamJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :medium
+  sidekiq_options queue: :data_cleanup
 
   def perform(spammable)
     return if Rails.env.test? || Rails.env.development?

--- a/app/jobs/assign_networks_job.rb
+++ b/app/jobs/assign_networks_job.rb
@@ -1,7 +1,7 @@
 class AssignNetworksJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :low
+  sidekiq_options queue: :network
 
   def perform(username)
     user = User.find_by_username(username)

--- a/app/jobs/award_job.rb
+++ b/app/jobs/award_job.rb
@@ -2,7 +2,7 @@ class AwardJob
   include Sidekiq::Worker
   include Awards
 
-  sidekiq_options queue: :high
+  sidekiq_options queue: :user
 
   def perform(badge, date, provider, candidate)
     award(badge.constantize, date, provider, candidate)

--- a/app/jobs/award_user_job.rb
+++ b/app/jobs/award_user_job.rb
@@ -1,7 +1,7 @@
 class AwardUserJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :low
+  sidekiq_options queue: :user
 
   def perform(username, badges)
     user = User.with_username(username)

--- a/app/jobs/build_activity_stream_job.rb
+++ b/app/jobs/build_activity_stream_job.rb
@@ -1,7 +1,7 @@
 class BuildActivityStreamJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :medium
+  sidekiq_options queue: :timeline
 
   def perform(username)
     user = User.with_username(username)

--- a/app/jobs/cleanup_protips_associate_zombie_upvotes_job.rb
+++ b/app/jobs/cleanup_protips_associate_zombie_upvotes_job.rb
@@ -1,7 +1,7 @@
 class CleanupProtipsAssociateZombieUpvotesJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :low
+  sidekiq_options queue: :data_cleanup
 
   def perform
     Like.joins('inner join users on users.tracking_code = likes.tracking_code').

--- a/app/jobs/clear_expired_sessions_job.rb
+++ b/app/jobs/clear_expired_sessions_job.rb
@@ -1,7 +1,7 @@
 class ClearExpiredSessionsJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :low
+  sidekiq_options queue: :data_cleanup
 
   def perform
     ActiveRecord::SessionStore::Session.delete_all(["updated_at < ?", 7.days.ago])

--- a/app/jobs/create_github_profile_job.rb
+++ b/app/jobs/create_github_profile_job.rb
@@ -2,7 +2,7 @@
 
 class CreateGithubProfileJob
   include Sidekiq::Worker
-  sidekiq_options queue: :low
+  sidekiq_options queue: :github
 
   def perform
     User.where('github is not null').find_each  do |user|

--- a/app/jobs/create_network_job.rb
+++ b/app/jobs/create_network_job.rb
@@ -1,7 +1,7 @@
 class CreateNetworkJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :low
+  sidekiq_options queue: :network
 
   def perform(tag)
     top_tags = Protip.trending_topics

--- a/app/jobs/deactivate_team_jobs_job.rb
+++ b/app/jobs/deactivate_team_jobs_job.rb
@@ -1,7 +1,7 @@
 class DeactivateTeamJobsJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :low
+  sidekiq_options queue: :team
 
   def perform(id)
     team = Team.find(id)

--- a/app/jobs/extract_github_profile.rb
+++ b/app/jobs/extract_github_profile.rb
@@ -1,6 +1,6 @@
 class ExtractGithubProfile
   include Sidekiq::Worker
-  sidekiq_options queue: :low
+  sidekiq_options queue: :github
 
 
   def perform(id)

--- a/app/jobs/generate_event_job.rb
+++ b/app/jobs/generate_event_job.rb
@@ -2,7 +2,7 @@
 class GenerateEventJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :high
+  sidekiq_options queue: :event_publisher
 
   def perform(event_type, audience, data, drip_rate=:immediately)
     data = HashWithIndifferentAccess.new(data)

--- a/app/jobs/generate_top_users_composite_job.rb
+++ b/app/jobs/generate_top_users_composite_job.rb
@@ -3,6 +3,8 @@
 class GenerateTopUsersCompositeJob
   include Sidekiq::Worker
 
+  sidekiq_options queue: :user
+
   IMAGE_PATH = Rails.root.join('public', 'images', 'top')
   WALL_IMAGE = IMAGE_PATH.join("wall.png")
 

--- a/app/jobs/geolocate_job.rb
+++ b/app/jobs/geolocate_job.rb
@@ -1,7 +1,7 @@
 class GeolocateJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :low
+  sidekiq_options queue: :user
 
   def perform
     User.active.not_geocoded.each do |user|

--- a/app/jobs/github_badge_org_job.rb
+++ b/app/jobs/github_badge_org_job.rb
@@ -1,7 +1,7 @@
 class GithubBadgeOrgJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :medium
+  sidekiq_options queue: :github
 
   def perform(username, action)
     user = User.with_username(username)

--- a/app/jobs/hawt_service_job.rb
+++ b/app/jobs/hawt_service_job.rb
@@ -1,7 +1,7 @@
 class HawtServiceJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :medium
+  sidekiq_options queue: :protip
 
   def perform(id, action)
     return '{}' unless Rails.env.production?

--- a/app/jobs/import_protip_job.rb
+++ b/app/jobs/import_protip_job.rb
@@ -1,7 +1,7 @@
-class ImportProtip
+class ImportProtipJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :low
+  sidekiq_options queue: :protip
 
   def perform(type, arg1)
     case type

--- a/app/jobs/index_protip_job.rb
+++ b/app/jobs/index_protip_job.rb
@@ -1,7 +1,7 @@
 class IndexProtipJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :high
+  sidekiq_options queue: :index
 
   def perform(protip_id)
     protip = Protip.find(protip_id)

--- a/app/jobs/index_team_job.rb
+++ b/app/jobs/index_team_job.rb
@@ -1,7 +1,7 @@
 class IndexTeamJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :high
+  sidekiq_options queue: :index
 
   def perform(team_id)
     team = Team.find(team_id)

--- a/app/jobs/merge_duplicate_link_job.rb
+++ b/app/jobs/merge_duplicate_link_job.rb
@@ -1,7 +1,7 @@
 class MergeDuplicateLinkJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :low
+  sidekiq_options queue: :data_cleanup
 
   def perform(link)
     all_links = ProtipLink.where(url: link).order('created_at ASC')

--- a/app/jobs/merge_skill_job.rb
+++ b/app/jobs/merge_skill_job.rb
@@ -1,7 +1,7 @@
 class MergeSkillJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :low
+  sidekiq_options queue: :data_cleanup
 
   def perform(incorrect_skill_id, correct_skill_name)
     incorrect_skill = Skill.find(incorrect_skill_id)

--- a/app/jobs/merge_tag_job.rb
+++ b/app/jobs/merge_tag_job.rb
@@ -1,7 +1,7 @@
 class MergeTagJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :low
+  sidekiq_options queue: :data_cleanup
 
   def perform(good_tag_id, bad_tag_id)
     bad_taggings = Tagging.select(:id).where(tag_id: bad_tag_id)

--- a/app/jobs/merge_tagging_job.rb
+++ b/app/jobs/merge_tagging_job.rb
@@ -1,7 +1,7 @@
 class MergeTaggingJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :low
+  sidekiq_options queue: :data_cleanup
 
   def perform(good_tag_id, bad_tagging_id)
     bad_tagging = Tagging.find(bad_tagging_id)

--- a/app/jobs/process_like_job.rb
+++ b/app/jobs/process_like_job.rb
@@ -1,7 +1,7 @@
 class ProcessLikeJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :high
+  sidekiq_options queue: :user
 
   def perform(process_type, like_id)
     like = Like.find(like_id)

--- a/app/jobs/process_protip_job.rb
+++ b/app/jobs/process_protip_job.rb
@@ -1,7 +1,7 @@
 class ProcessProtipJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :low
+  sidekiq_options queue: :protip
 
   def perform(process_type, protip_id)
     protip = Protip.find(protip_id)

--- a/app/jobs/process_team_job.rb
+++ b/app/jobs/process_team_job.rb
@@ -1,7 +1,7 @@
 class ProcessTeamJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :low
+  sidekiq_options queue: :team
 
   def perform(process_type, team_id)
     team = Team.find(team_id)

--- a/app/jobs/protip_indexer_worker.rb
+++ b/app/jobs/protip_indexer_worker.rb
@@ -1,7 +1,7 @@
 class ProtipIndexerWorker
   include Sidekiq::Worker
 
-  sidekiq_options :queue =>  :high
+  sidekiq_options :queue =>  :index
 
   def perform(protip_id)
     protip = Protip.find(protip_id)

--- a/app/jobs/protips_recalculate_scores_job.rb
+++ b/app/jobs/protips_recalculate_scores_job.rb
@@ -1,7 +1,7 @@
 class ProtipsRecalculateScoresJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :low
+  sidekiq_options queue: :protip
 
   def perform
     Protip.where('created_at > ?', 25.hours.ago).where(upvotes_value_cache: nil).each do |protip|

--- a/app/jobs/refresh_timeline_job.rb
+++ b/app/jobs/refresh_timeline_job.rb
@@ -1,7 +1,7 @@
 class RefreshTimelineJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :medium
+  sidekiq_options queue: :timeline
 
   def perform(username)
     user = User.find_by_username(username)

--- a/app/jobs/refresh_user_job.rb
+++ b/app/jobs/refresh_user_job.rb
@@ -1,6 +1,6 @@
 class RefreshUserJob
   include Sidekiq::Worker
-  sidekiq_options queue: :low
+  sidekiq_options queue: :user
 
   def perform(user_id, full=false)
     return if Rails.env.test?

--- a/app/jobs/resize_tilt_shift_banner_job.rb
+++ b/app/jobs/resize_tilt_shift_banner_job.rb
@@ -1,7 +1,7 @@
 class ResizeTiltShiftBannerJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :high
+  sidekiq_options queue: :user
 
   def perform(klass, id, column)
     image = klass.constantize.find(id)

--- a/app/jobs/reverse_geolocate_user_job.rb
+++ b/app/jobs/reverse_geolocate_user_job.rb
@@ -4,7 +4,7 @@ class ReverseGeolocateUserJob
   include Sidekiq::Worker
   include ReverseGeocoder
 
-  sidekiq_options queue: :high
+  sidekiq_options queue: :user
 
   def perform(username, ip_address)
     user = User.find_by_username(username)

--- a/app/jobs/seed_github_protips_job.rb
+++ b/app/jobs/seed_github_protips_job.rb
@@ -1,7 +1,7 @@
 class SeedGithubProtipsJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :low
+  sidekiq_options queue: :github
 
   def perform(username)
     user = User.with_username(username)

--- a/app/jobs/teams_refresh_job.rb
+++ b/app/jobs/teams_refresh_job.rb
@@ -1,7 +1,7 @@
 class TeamsRefreshJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :low
+  sidekiq_options queue: :team
 
   def perform
     Team.all.each do |team|

--- a/app/jobs/track_event_job.rb
+++ b/app/jobs/track_event_job.rb
@@ -1,7 +1,7 @@
 class TrackEventJob
   include Sidekiq::Worker
 
-  sidekiq_options queue: :critical
+  sidekiq_options queue: :event_tracker
 
   def perform(name, params, request_ip)
     mixpanel(request_ip).track(name, params)

--- a/app/jobs/update_network_job.rb
+++ b/app/jobs/update_network_job.rb
@@ -3,7 +3,7 @@ class UpdateNetworkJob
   #OPTIMIZE
   include Sidekiq::Worker
 
-  sidekiq_options queue: :high
+  sidekiq_options queue: :network
 
   def perform(update_type, public_id, data)
     protip = Protip.with_public_id(public_id)

--- a/app/workers/activate_pending_users_worker.rb
+++ b/app/workers/activate_pending_users_worker.rb
@@ -1,6 +1,6 @@
 class ActivatePendingUsersWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :critical
+  sidekiq_options queue: :user
 
   def perform
     # Spawning possibly many thousands

--- a/app/workers/protip_mailer_popular_protips_send_worker.rb
+++ b/app/workers/protip_mailer_popular_protips_send_worker.rb
@@ -1,6 +1,6 @@
 class ProtipMailerPopularProtipsSendWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :low
+  sidekiq_options queue: :mailer
 
   def perform(user_id, protip_ids, from, to)
     fail "Only #{protip_ids.count} protips but expected 10" unless protip_ids.count == 10

--- a/app/workers/protip_mailer_popular_protips_worker.rb
+++ b/app/workers/protip_mailer_popular_protips_worker.rb
@@ -1,6 +1,6 @@
 class ProtipMailerPopularProtipsWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :low
+  sidekiq_options queue: :mailer
 
   def perform(from, to)
 

--- a/app/workers/refresh_stale_users_worker.rb
+++ b/app/workers/refresh_stale_users_worker.rb
@@ -1,6 +1,6 @@
 class RefreshStaleUsersWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :critical
+  sidekiq_options queue: :user
 
   def perform
     user_records.find_each(batch_size: 1000) do |user|

--- a/app/workers/sitemap_refresh_worker.rb
+++ b/app/workers/sitemap_refresh_worker.rb
@@ -1,7 +1,7 @@
 class SitemapRefreshWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :sitemap_generator
+  sidekiq_options queue: :index
 
   def perform
     # ArgumentError: Missing host to link to! Please provide the :host parameter, set default_path_options[:host], or set :only_path to true

--- a/app/workers/user_activate_worker.rb
+++ b/app/workers/user_activate_worker.rb
@@ -1,6 +1,6 @@
 class UserActivateWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :high
+  sidekiq_options queue: :user
 
   def perform(user_id)
     user = User.find(user_id)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -5,6 +5,17 @@ staging:
 production:
   :concurrency: <%= ENV['SIDEKIQ_CONCURRENCY'] || 20 %>
 :queues:
+  - [event_tracker,   5]
+  - [index,           4]
+  - [timeline,        3]
+  - [user,            2]
+  - [data_cleanup,    1]
+  - [event_publisher, 1]
+  - [github,          1]
+  - [mailer,          1]
+  - [network,         1]
+  - [protip,          1]
+  - [team,            1]
   - [low,      1]
   - [default,  2]
   - [search_sync, 2]

--- a/spec/jobs/analyze_spam_job_spec.rb
+++ b/spec/jobs/analyze_spam_job_spec.rb
@@ -1,5 +1,14 @@
-#FIXME
-#RSpec.describe AnalyzeSpamJob, skip: true do
+require 'sidekiq/testing'
+
+RSpec.describe AnalyzeSpamJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(AnalyzeSpamJob.get_sidekiq_options["queue"]).to eql :data_cleanup
+    end
+  end
+
+# TODO FIXME
 #  describe '#perform' do
 #    context 'when it is a spam' do
 #      it 'should create a spam report' do
@@ -19,4 +28,4 @@
 #      end
 #    end
 #  end
-#end
+end

--- a/spec/jobs/assign_networks_job_spec.rb
+++ b/spec/jobs/assign_networks_job_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe AssignNetworksJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(AssignNetworksJob.get_sidekiq_options["queue"]).to eql :network
+    end
+  end
+
+end

--- a/spec/jobs/award_job_spec.rb
+++ b/spec/jobs/award_job_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe AwardJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(AwardJob.get_sidekiq_options["queue"]).to eql :user
+    end
+  end
+
+end

--- a/spec/jobs/award_user_job_spec.rb
+++ b/spec/jobs/award_user_job_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe AwardUserJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(AwardUserJob.get_sidekiq_options["queue"]).to eql :user
+    end
+  end
+
+end

--- a/spec/jobs/build_activity_stream_job_spec.rb
+++ b/spec/jobs/build_activity_stream_job_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe BuildActivityStreamJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(BuildActivityStreamJob.get_sidekiq_options["queue"]).
+        to eql :timeline
+    end
+  end
+
+end

--- a/spec/jobs/cleanup_protips_associate_zombie_upvotes_job_spec.rb
+++ b/spec/jobs/cleanup_protips_associate_zombie_upvotes_job_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe CleanupProtipsAssociateZombieUpvotesJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(CleanupProtipsAssociateZombieUpvotesJob.
+        get_sidekiq_options["queue"]).to eql :data_cleanup
+    end
+  end
+
+end

--- a/spec/jobs/clear_expired_sessions_job_spec.rb
+++ b/spec/jobs/clear_expired_sessions_job_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe ClearExpiredSessionsJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(ClearExpiredSessionsJob.get_sidekiq_options["queue"]).
+        to eql :data_cleanup
+    end
+  end
+
+end

--- a/spec/jobs/create_github_profile_job_spec.rb
+++ b/spec/jobs/create_github_profile_job_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe CreateGithubProfileJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(CreateGithubProfileJob.get_sidekiq_options["queue"]).to eql :github
+    end
+  end
+
+end

--- a/spec/jobs/create_network_job_spec.rb
+++ b/spec/jobs/create_network_job_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe CreateNetworkJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(CreateNetworkJob.get_sidekiq_options["queue"]).to eql :network
+    end
+  end
+
+end

--- a/spec/jobs/deactivate_team_jobs_job_spec.rb
+++ b/spec/jobs/deactivate_team_jobs_job_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe DeactivateTeamJobsJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(DeactivateTeamJobsJob.get_sidekiq_options["queue"]).to eql :team
+    end
+  end
+
+end

--- a/spec/jobs/extract_github_profile_spec.rb
+++ b/spec/jobs/extract_github_profile_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe ExtractGithubProfile do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(ExtractGithubProfile.get_sidekiq_options["queue"]).to eql :github
+    end
+  end
+
+end

--- a/spec/jobs/generate_event_job_spec.rb
+++ b/spec/jobs/generate_event_job_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe GenerateEventJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(GenerateEventJob.get_sidekiq_options["queue"]).
+        to eql :event_publisher
+    end
+  end
+
+end

--- a/spec/jobs/generate_top_users_composite_job_spec.rb
+++ b/spec/jobs/generate_top_users_composite_job_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe GenerateTopUsersCompositeJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(GenerateTopUsersCompositeJob.get_sidekiq_options["queue"]).
+        to eql :user
+    end
+  end
+
+end

--- a/spec/jobs/geolocate_job_spec.rb
+++ b/spec/jobs/geolocate_job_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe GeolocateJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(GeolocateJob.get_sidekiq_options["queue"]).to eql :user
+    end
+  end
+
+end

--- a/spec/jobs/github_badge_org_job_spec.rb
+++ b/spec/jobs/github_badge_org_job_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe GithubBadgeOrgJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(GithubBadgeOrgJob.get_sidekiq_options["queue"]).to eql :github
+    end
+  end
+
+end

--- a/spec/jobs/hawt_service_job_spec.rb
+++ b/spec/jobs/hawt_service_job_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe HawtServiceJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(HawtServiceJob.get_sidekiq_options["queue"]).to eql :protip
+    end
+  end
+
+end

--- a/spec/jobs/import_protip_job_spec.rb
+++ b/spec/jobs/import_protip_job_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe ImportProtipJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(ImportProtipJob.get_sidekiq_options["queue"]).to eql :protip
+    end
+  end
+
+end

--- a/spec/jobs/index_protip_job_spec.rb
+++ b/spec/jobs/index_protip_job_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe IndexProtipJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(IndexProtipJob.get_sidekiq_options["queue"]).to eql :index
+    end
+  end
+
+end

--- a/spec/jobs/index_team_job_spec.rb
+++ b/spec/jobs/index_team_job_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe IndexTeamJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(IndexTeamJob.get_sidekiq_options["queue"]).to eql :index
+    end
+  end
+
+end

--- a/spec/jobs/merge_duplicate_link_job_spec.rb
+++ b/spec/jobs/merge_duplicate_link_job_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe MergeDuplicateLinkJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(MergeDuplicateLinkJob.get_sidekiq_options["queue"]).
+        to eql :data_cleanup
+    end
+  end
+
+end

--- a/spec/jobs/merge_skill_job_spec.rb
+++ b/spec/jobs/merge_skill_job_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe MergeSkillJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(MergeSkillJob.get_sidekiq_options["queue"]).to eql :data_cleanup
+    end
+  end
+
+end

--- a/spec/jobs/merge_tag_job_spec.rb
+++ b/spec/jobs/merge_tag_job_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe MergeTagJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(MergeTagJob.get_sidekiq_options["queue"]).to eql :data_cleanup
+    end
+  end
+
+end

--- a/spec/jobs/merge_tagging_job_spec.rb
+++ b/spec/jobs/merge_tagging_job_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe MergeTaggingJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(MergeTaggingJob.get_sidekiq_options["queue"]).to eql :data_cleanup
+    end
+  end
+
+end

--- a/spec/jobs/process_like_job_spec.rb
+++ b/spec/jobs/process_like_job_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe ProcessLikeJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(ProcessLikeJob.get_sidekiq_options["queue"]).to eql :user
+    end
+  end
+
+end

--- a/spec/jobs/process_protip_job_spec.rb
+++ b/spec/jobs/process_protip_job_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe ProcessProtipJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(ProcessProtipJob.get_sidekiq_options["queue"]).to eql :protip
+    end
+  end
+
+end

--- a/spec/jobs/process_team_job_spec.rb
+++ b/spec/jobs/process_team_job_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe ProcessTeamJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(ProcessTeamJob.get_sidekiq_options["queue"]).to eql :team
+    end
+  end
+
+end

--- a/spec/jobs/protip_indexer_worker_spec.rb
+++ b/spec/jobs/protip_indexer_worker_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe ProtipIndexerWorker do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(ProtipIndexerWorker.get_sidekiq_options["queue"]).to eql :index
+    end
+  end
+
+end

--- a/spec/jobs/protips_recalculate_scores_job_spec.rb
+++ b/spec/jobs/protips_recalculate_scores_job_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe ProtipsRecalculateScoresJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(ProtipsRecalculateScoresJob.get_sidekiq_options["queue"]).
+        to eql :protip
+    end
+  end
+
+end

--- a/spec/jobs/refresh_timeline_job_spec.rb
+++ b/spec/jobs/refresh_timeline_job_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe RefreshTimelineJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(RefreshTimelineJob.get_sidekiq_options["queue"]).
+        to eql :timeline
+    end
+  end
+
+end

--- a/spec/jobs/refresh_user_job_spec.rb
+++ b/spec/jobs/refresh_user_job_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe RefreshUserJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(RefreshUserJob.get_sidekiq_options["queue"]).to eql :user
+    end
+  end
+
+end

--- a/spec/jobs/resize_tilt_shift_banner_job_spec.rb
+++ b/spec/jobs/resize_tilt_shift_banner_job_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe ResizeTiltShiftBannerJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(ResizeTiltShiftBannerJob.get_sidekiq_options["queue"]).to eql :user
+    end
+  end
+
+end

--- a/spec/jobs/reverse_geolocate_user_job_spec.rb
+++ b/spec/jobs/reverse_geolocate_user_job_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe ReverseGeolocateUserJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(ReverseGeolocateUserJob.get_sidekiq_options["queue"]).to eql :user
+    end
+  end
+
+end

--- a/spec/jobs/search_sync_job_spec.rb
+++ b/spec/jobs/search_sync_job_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe SearchSyncJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(SearchSyncJob.get_sidekiq_options["queue"]).to eql :search_sync
+    end
+  end
+
+end

--- a/spec/jobs/seed_github_protips_job_spec.rb
+++ b/spec/jobs/seed_github_protips_job_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe SeedGithubProtipsJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(SeedGithubProtipsJob.get_sidekiq_options["queue"]).to eql :github
+    end
+  end
+
+end

--- a/spec/jobs/teams_refresh_job_spec.rb
+++ b/spec/jobs/teams_refresh_job_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe TeamsRefreshJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(TeamsRefreshJob.get_sidekiq_options["queue"]).to eql :team
+    end
+  end
+
+end

--- a/spec/jobs/track_event_job_spec.rb
+++ b/spec/jobs/track_event_job_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe TrackEventJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(TrackEventJob.get_sidekiq_options["queue"]).to eql :event_tracker
+    end
+  end
+
+end

--- a/spec/jobs/update_network_job_spec.rb
+++ b/spec/jobs/update_network_job_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe UpdateNetworkJob do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(UpdateNetworkJob.get_sidekiq_options["queue"]).to eql :network
+    end
+  end
+
+end

--- a/spec/workers/activate_pending_users_worker_spec.rb
+++ b/spec/workers/activate_pending_users_worker_spec.rb
@@ -1,5 +1,8 @@
-require 'sidekiq/testing'
-Sidekiq::Testing.inline!
-
 RSpec.describe ActivatePendingUsersWorker do
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(ActivatePendingUsersWorker.get_sidekiq_options["queue"]).
+        to eql :user
+    end
+  end
 end

--- a/spec/workers/protip_mailer_popular_protips_send_worker_spec.rb
+++ b/spec/workers/protip_mailer_popular_protips_send_worker_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe ProtipMailerPopularProtipsSendWorker do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(ProtipMailerPopularProtipsSendWorker.get_sidekiq_options["queue"]).
+        to eql :mailer
+    end
+  end
+
+end

--- a/spec/workers/protip_mailer_popular_protips_worker_spec.rb
+++ b/spec/workers/protip_mailer_popular_protips_worker_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe ProtipMailerPopularProtipsWorker do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(ProtipMailerPopularProtipsWorker.get_sidekiq_options["queue"]).
+        to eql :mailer
+    end
+  end
+
+end

--- a/spec/workers/refresh_stale_users_worker_spec.rb
+++ b/spec/workers/refresh_stale_users_worker_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe RefreshStaleUsersWorker do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(RefreshStaleUsersWorker.get_sidekiq_options["queue"]).to eql :user
+    end
+  end
+
+end

--- a/spec/workers/sitemap_refresh_worker_spec.rb
+++ b/spec/workers/sitemap_refresh_worker_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe SitemapRefreshWorker do
+
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(SitemapRefreshWorker.get_sidekiq_options["queue"]).to eql :index
+    end
+  end
+
+end

--- a/spec/workers/user_activate_worker_spec.rb
+++ b/spec/workers/user_activate_worker_spec.rb
@@ -5,6 +5,12 @@ Sidekiq::Testing.inline!
 RSpec.describe UserActivateWorker do
   let(:worker) { UserActivateWorker.new }
 
+  describe 'queueing' do
+    it 'pushes jobs to the correct queue' do
+      expect(UserActivateWorker.get_sidekiq_options["queue"]).to eql :user
+    end
+  end
+
   describe('#perform') do
     context 'when invalid user' do
       let(:user_id) { 1 }


### PR DESCRIPTION
# [Split up Sidekiq work across more specific queues. #422](https://assembly.com/coderwall/bounties/422)

New sidekiq queues & priorities:
- event_tracker - 5
- index - 4
- timeline -  3
- search_sync - 2
- user - 2
- data_cleanup - 1
- event_publisher - 1
- github - 1
- mailer - 1
- network - 1
- protip - 1
- team - 1

:information_source: A 2nd PR that removes the old queues from sidekiq.yml will need to be created after this is deployed to production. Jobs queued up during the deploy still need to be worked, that is why the OLD queues are not removed by this PR.  Once the OLD queues are worked & emptied, then the 2nd PR can merged and deployed :information_source: 
