### PR TITLE
WIP-425 Was getting a 404 when trying to download libcurl4-openssl-dev, ...

### DIFF
--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -1,6 +1,8 @@
 #!/bin/bash -x
 export DEBIAN_FRONTEND=noninteractive
 
+apt-get update
+
 apt-get -y install ack-grep
 apt-get -y install autoconf
 apt-get -y install automake


### PR DESCRIPTION
...doing an apt-get update fixed it.

Looks like maybe the files got moved or something? I ran `apt-get update` and `apt-get -y install libcurl4-openssl-dev` worked instead of giving me a 404. I did a `vagrant destroy` and then ran `run.bat` again. Server is up and running, now.
