### PR TITLE
Quick fix the user protip route #418

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Coderwall::Application.routes.draw do
 
   resources :protips, :path => '/p' do
     collection do
+      get 'u/:username' => 'protips#user', as: :user
       get ':id/:slug' => 'protips#show', as: :slug, :constraints => {:slug => /(?!.*?edit).*/}
       get 'random'
       get 'search' => 'protips#search', as: :search
@@ -34,7 +35,6 @@ Coderwall::Application.routes.draw do
       get 'd/:date(/:start)' => 'protips#date', as: :date
       get 't/trending' => 'protips#trending', as: :trending_topics
       get 't/by_tags' => 'protips#by_tags', as: :by_tags
-      get 'u/:username' => 'protips#user', as: :user
       get 't/(/*tags)' => 'networks#tag', as: :tagged
       put 't/(/*tags)/subscribe' => 'protips#subscribe', as: :subscribe
       put 't/(/*tags)/unsubscribe' => 'protips#unsubscribe', as: :unsubscribe


### PR DESCRIPTION
This is a quick fix for the bug reported at [#418](https://assembly.com/coderwall/bounties/418), but I highly recommend to revise all the protips routes since it looks a little messy.
