### PR TITLE
fix New Relic team promo UI problems - Bounty #440

### DIFF
--- a/app/assets/stylesheets/jobs.scss
+++ b/app/assets/stylesheets/jobs.scss
@@ -18,11 +18,11 @@
   margin-bottom: 60px;
 
   .inside {
-    height: 210px;
-    padding: 60px 15px;
+    height: 550px;
+    padding: 60px 0px;
     width: 870px;
     margin: 0 auto;
-    background: image-url("relic-tee.png") no-repeat right 102px;
+    background: image-url("relic-tee.png") no-repeat right 160px;
   }
 
   h1 {
@@ -60,6 +60,7 @@
     text-transform: uppercase;
     color: #fff;
     text-align: center;
+    float: right;
 
     &:hover {
       background: $green;

--- a/app/views/teams/_new_relic.html.haml
+++ b/app/views/teams/_new_relic.html.haml
@@ -1,6 +1,6 @@
 .relic-bar
   .inside
     %h1 Level up your wardrobe with this tee!
-    %p Coderwall helps you level up your skills and New Relic helps you level up your app. Now when you try out New Relic for free, they'll send you this Coderwall tee.
     %a.test-drive.track{:href => 'http://newrelic.com/sp/coderwall?utm_source=CWAL&utm_medium=promotion&utm_content=coderwall&utm_campaign=coderwall&mpc=PM-CWAL-web-Signup-100-coderwall-shirtpromo', 'data-action' => 'go get tee', :target => :new}
       Get a free Coderwall tee
+    %p Coderwall helps you level up your skills and New Relic helps you level up your app. Now when you try out New Relic for free, they'll send you this Coderwall tee.


### PR DESCRIPTION
## [New Relic team page UI bugs - Bounty 440](https://assembly.com/coderwall/bounties/440)
- un-hide the promo copy
- show the entire promo t-shirt image
- align promo copy with image
- move call to action to the right side per @mdeiters' request

With these fixes, it looks like this
![team_new_relic___coderwall_com](https://cloud.githubusercontent.com/assets/987305/5328414/b3bb8ea2-7d38-11e4-8fd9-9f882735215c.png)
