### PR TITLE
disable registration submit button after 1 click

### DIFF
--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -36,10 +36,11 @@
         /   =form.label      :receive_newsletter, 'Receive infrequent but relevant updates'.html_safe
         %p.neverpost
           We respect the sanctity of your email and share your dislike for spam and unnecessarily frequent newsletters.
-          =follow_coderwall_on_twitter
+          = follow_coderwall_on_twitter
           to stay up to date with updates from coderwall.
         .save
-          =submit_tag 'Finish', :class => 'button'
+          = submit_tag 'Finish', class: 'button',
+            data: { disable_with: "Submitted" }
       .clear
       .special-setting.already-signedup
         %h4


### PR DESCRIPTION
## [Bounty 446 - BUG: PG::UniqueViolation: ERROR: duplicate key value violates unique constraint "index_users_on_username" DETAIL: Key (username)=(XXXXXXX) already exists.](https://assembly.com/coderwall/bounties/446)

I have seen this sort of problem in the past on other projects. Adding `data: { disable_with: "Submitted" }` to a submit_tag or link_to disables the button after the first click. I smoke tested locally and it works as advertised.  For more info: http://www.railsonmaui.com/blog/2014/02/23/simple-form-and-disable-processing-by-default/

BTW, our `validates_uniqueness_of :username` does work, but double clicks create a race condition. :racehorse: :car::dash:
