### PR TITLE
destroy zombie likes when likable is invalid - Bounty 456

### DIFF
--- a/app/jobs/process_like_job.rb
+++ b/app/jobs/process_like_job.rb
@@ -8,10 +8,13 @@ class ProcessLikeJob
     case process_type
       when 'associate_to_user'
         begin
-          like.user_id = User.find_by_tracking_code(like.tracking_code)
-          like.save!
-        rescue ActiveRecord::RecordNotUnique => ex
-          ap ex
+          if user = User.find_by_tracking_code(like.tracking_code)
+            like.user = user
+            like.save!
+          else
+            like.destroy
+          end
+        rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => ex
           like.destroy
         end
     end

--- a/spec/jobs/process_like_job_spec.rb
+++ b/spec/jobs/process_like_job_spec.rb
@@ -6,4 +6,49 @@ RSpec.describe ProcessLikeJob do
     end
   end
 
+  describe 'processing' do
+    let(:user) { Fabricate(:user, tracking_code: 'fake_tracking_code') }
+    let(:protip) { Fabricate(:protip) }
+
+    it 'associates the zombie like to the correct user' do
+      zombie_like = Fabricate(:like, likable: protip,
+        tracking_code: user.tracking_code)
+
+      ProcessLikeJob.new.perform('associate_to_user', zombie_like.id)
+
+      zombie_like.reload
+
+      expect(zombie_like.user_id).to eql user.id
+    end
+
+    it 'destroys like that are invalid' do
+      invalid_like = Like.new(value: 1, tracking_code: user.tracking_code)
+      invalid_like.save(validate: false)
+
+      ProcessLikeJob.new.perform('associate_to_user', invalid_like.id)
+
+      expect(Like.where(id: invalid_like.id)).not_to exist
+    end
+
+    it 'destroys likes that are non-unique' do
+      original_like = Fabricate(:like, user: user, likable: protip)
+
+      duplicate_like = Fabricate(:like, likable: protip,
+        tracking_code: user.tracking_code)
+
+      ProcessLikeJob.new.perform('associate_to_user', duplicate_like.id)
+
+      expect(Like.where(id: duplicate_like.id)).not_to exist
+    end
+
+    it 'destroys likes if no user with the tracking code exists' do
+      unassociatable_like = Fabricate(:like, likable: protip,
+        tracking_code: 'unassociatable_tracking_code')
+
+      ProcessLikeJob.new.perform('associate_to_user', unassociatable_like.id)
+
+      expect(Like.where(id: unassociatable_like.id)).not_to exist
+    end
+  end
+
 end


### PR DESCRIPTION
## [BUG: ActiveRecord::RecordInvalid: Validation failed: Likable can't be blank - Bounty 456](https://assembly.com/coderwall/bounties/456)

The code will now handle when the zombie like has an invalid likable :smile_cat: 
