### PR TITLE
Bounty #455 - Fix User#on_team?

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -225,6 +225,14 @@ class User < ActiveRecord::Base
     end
   end
 
+  def team
+    if team_id
+      Team.find(team_id)
+    else
+      membership.try(:team)
+    end
+  end
+
   def team_ids
     [team_id]
   end
@@ -248,7 +256,7 @@ class User < ActiveRecord::Base
   end
 
   def on_team?
-    not team_document_id.nil?
+    team_id.present? || membership.present?
   end
 
   def team_member_of?(user)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -214,6 +214,23 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '#team' do
+    let(:team) { Fabricate(:team) }
+    let(:user) { Fabricate(:user) }
+    it 'returns membership team if user has membership' do
+      team.add_member(user)
+      expect(user.team).to eq(team)
+    end
+    it 'returns team if team_id is set' do
+      user.team_id = team.id
+      user.save
+      expect(user.team).to eq(team)
+    end
+    it 'returns nil if no team_id or membership' do
+      expect(user.team).to eq(nil)
+    end
+  end
+
   it 'should indicate when user is on a premium team' do
     team = Fabricate(:team, premium: true)
     member = team.add_member(user = Fabricate(:user))
@@ -232,6 +249,22 @@ RSpec.describe User, type: :model do
     team.add_member(user)
     team.destroy
     expect(user.team).to be_nil
+  end
+
+  describe '#on_team?' do
+    let(:team) { Fabricate(:team) }
+    let(:user) { Fabricate(:user) }
+    it 'is true if user has a membership' do
+      expect(user.on_team?).to eq(false)
+      team.add_member(user)
+      expect(user.reload.on_team?).to eq(true)
+    end
+    it 'is true if user is on a team' do
+      expect(user.on_team?).to eq(false)
+      user.team = team
+      user.save
+      expect(user.reload.on_team?).to eq(true)
+    end
   end
 
   it 'can follow another user' do


### PR DESCRIPTION
https://assembly.com/coderwall/bounties/455

Currently the welcome email checks if `@user.on_team?` and then if they are presents some info referencing `@user.team` https://github.com/assemblymade/coderwall/blob/master/app/views/notifier_mailer/welcome_email.html.haml#L20
`User#on_team?` previously checked for `team_document_id`. I talked with @seuros who told me that `team_document_id` is deprecated and will be removed, and that we're temporarily using `team_id` until support for belonging to multiple teams is  added. 

I've updated `User#on_team?` to check if a user has a `team_id` or a `membership`. I also updated `User#team` so that it returns the team associated with the `membership` (but also still supports associating teams  by `team_id`).

This is my first PR on this project and this is one of the larger, more complex projects I've worked on so let me know if there is anything I should be doing differently. 
