### PR TITLE
Bounty #459 - Fix 

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -57,7 +57,7 @@ class TeamsController < ApplicationController
         @job = show_params[:job_id].nil? ? @team.jobs.sample : Opportunity.with_public_id(show_params[:job_id])
 
         @other_jobs = @team.jobs.reject { |job| job.id == @job.id } unless @job.nil?
-        @job_page = show_params[:job_id].present?
+        @job_page = !@job.nil?
         return render(:premium) if show_premium_page?
       end
 

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -36,6 +36,16 @@ RSpec.describe TeamsController, type: :controller, skip: true do
       expect(response).to be_success
       expect(response).to have_http_status(200)
     end
+    it 'sets job_page to true if job is found' do
+      opporunity = Fabricate(:opportunity)
+      get :show, slug: opportunity.team.slug, job_id: opportunity.public_id
+      expect(assigns(:job_page)).to eq(true)
+    end
+    it 'sets job_page to false if job is not found' do
+      team = Fabricate(:team)
+      get :show, slug: team.slug, job_id: 'not-a-real-job-slug'
+      expect(assigns(:job_page)).to eq(false)
+    end
   end
 
   describe '#create' do


### PR DESCRIPTION
https://assembly.com/coderwall/bounties/459

Before, the TeamsController would set `@job_page` to true if there was anything in `params[:job_id]`. This caused problems because if a job id that didn't actually match anything in the database, the template would still try to call methods on `@job` even though it was nil. 

This PR changes it so that `@job_page` is based on whether or not a job was found and loaded, rather than just the presence of `show_params[:job_id]`
