### PR TITLE
Change `add_team_member` to `add_team_membership` method

### DIFF
--- a/app/models/github_badge.rb
+++ b/app/models/github_badge.rb
@@ -18,7 +18,7 @@ class GithubBadge
 
     id = @client.organization_teams("coderwall-#{badge_name}")[1].id
 
-    @client.add_team_member(id, github_username)
+    @client.add_team_membership(id, github_username)
   rescue Octokit::NotFound => e
     Rails.logger.error("Failed to add badge #{badge_name} for #{github_username}") if ENV['DEBUG']
   rescue Errno::ECONNREFUSED => e


### PR DESCRIPTION
add_team_member method is deprecated

SEE ALSO:
https://developer.github.com/changes/2014-08-05-team-memberships-api/