### PR TITLE
Fix 404 pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -182,7 +182,10 @@ class ApplicationController < ActionController::Base
   end
 
   def render_404
-    render template: 'errors/not_found', status: :not_found
+    respond_to do |format|
+      format.any(:html, :json, :xml) { render 'errors/not_found', status: :not_found }
+      format.all { render text: "Not Found", :content_type => Mime::TEXT, status: :not_found }
+    end
   end
 
   def render_500


### PR DESCRIPTION
[Bounty#492](https://assembly.com/coderwall/bounties/492)

```ActionView::MissingTemplate: Missing template errors/not_found with {:locale=>[:en], :formats=>[:png], :handlers=>[:erb, :builder, :slim, :jbuilder, :coffee, :haml]}. Searched in: * "/app/app/views" * "/app/vendor/bundle/ruby/2.1.0/gems/kaminari-0.16.1/app/views"```

Currently, a 404 only responds to html, json and xml. This should respond to all formats.

This error has occurred **21744** times till now.