### PR TITLE
Fix JSON endpoints for Teams

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -241,9 +241,7 @@ class Team < ActiveRecord::Base
   end
 
   def public_hash
-    neighbors = Team.find((higher_competitors(5) + lower_competitors(5)).flatten.uniq)
     summary.merge(
-      neighbors:    neighbors.collect(&:summary),
       members: members.collect { |user| {
         name:               user.display_name,
         username:           user.username,

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe Team, type: :model do
   let(:invitee)      { Fabricate(:user) }
 
   it { is_expected.to have_one :account }
-
   it { is_expected.to have_many :locations }
   it { is_expected.to have_many :links }
   it { is_expected.to have_many :members }
@@ -26,6 +25,15 @@ RSpec.describe Team, type: :model do
       result = Team.with_similar_names('dr%')
       expect(result).to include(team_1, team_2)
     end
+  end
+
+  describe "#public_json" do
+
+    it "returns valid JSON" do
+      json = team.public_json
+      expect{JSON.parse(json)}.to_not raise_error
+    end
+
   end
 
   it 'adds the team id to the user when they are added to a team' do
@@ -90,11 +98,5 @@ RSpec.describe Team, type: :model do
     Plan.create(amount: 19_900, interval: nil, name: 'Single') if Plan.enhanced_team_page_one_time.nil?
     Plan.create(amount: 19_900, interval: Plan::MONTHLY, analytics: true, name: 'Analytics') if Plan.enhanced_team_page_analytics.nil?
   end
-
-  it { is_expected.to have_many :locations }
-  it { is_expected.to have_many :links }
-  it { is_expected.to have_many :members }
-  it { is_expected.to have_many :jobs }
-  it { is_expected.to have_many :followers }
 
 end


### PR DESCRIPTION
[Bounty #493](https://assembly.com/coderwall/bounties/493).

Hitting JSON endpoints for teams results in a 500 error. 

```
NoMethodError: undefined method `higher_competitors' for #<Team:0x007f15462b4118>
```

URL: https://coderwall.com/team/bugsnag.json

This error has been seen 12 times. 

Looks like there are few old/deleted methods that are being called. 