### PR TITLE
Remove deprecated String#to_a in Networks#show

### DIFF
--- a/app/controllers/networks_controller.rb
+++ b/app/controllers/networks_controller.rb
@@ -215,7 +215,7 @@ class NetworksController < ApplicationController
   end
 
   def redirect_to_search
-    tags = @network.try(:slug).try(:to_a) || (params[:tags] && params[:tags].split('/')) || []
+    tags = @network.try(:slug).try(:split) || (params[:tags] && params[:tags].split('/')) || []
     tags = tags.map { |tag| "##{tag}" }.join(' ')
     redirect_to protips_path(search: tags, show_all: params[:show_all])
   end

--- a/app/models/network.rb
+++ b/app/models/network.rb
@@ -102,7 +102,7 @@ class Network < ActiveRecord::Base
 
   def correct_tags
     if self.tag_list_changed?
-      self.tags_list = self.tag_list.uniq.select { |tag| Tag.exists?(name: tag) }.reject { |tag| (tag != self.name) && Network.exists?(name: tag) }
+      self.tag_list = self.tag_list.uniq.select { |tag| Tag.exists?(name: tag) }.reject { |tag| (tag != self.name) && Network.exists?(name: tag) }
     end
   end
 


### PR DESCRIPTION
[Bounty#501](https://assembly.com/coderwall/bounties/501)

This also fixes a small issue that was leftover from #279