### PR TITLE
remove existing changeLog'd API integration - Bounty #488 - take two

### DIFF
--- a/app/models/badges/changelogd.rb
+++ b/app/models/badges/changelogd.rb
@@ -1,5 +1,4 @@
-# TODO: broken
-!class Changelogd < BadgeBase
+class Changelogd < BadgeBase
   describe "Changelog'd",
            skill:       'Open Source',
            description: "Have an original repo featured on the Changelog show",
@@ -8,72 +7,8 @@
            weight:      2,
            providers:   :github
 
-  API_URI   = "http://thechangelog.com/api/read" # tagged=episode & tagged=github
-  REPO      = /([http|https]*:\/\/github\.com\/[\w | \-]*\/[\w | \-]*)/i
-  USERNAME  = /github\.com\/([\w | \-]*)\/[\w | \-]*/i
-  REPO_NAME = /github\.com\/[\S|\D]*\/([\S|\D]*)/i
-
-  def reasons
-    @reasons ||= begin
-      links = user.facts.select do |fact|
-        fact.tagged?('changedlog')
-      end.collect do |fact|
-        begin
-          match = fact.url.match(REPO_NAME)
-          { match[1] => fact.url }
-        rescue
-          { fact.url => fact.url }
-        end
-      end
-      { links: links }
-    end
-  end
-
   def award?
-    !reasons[:links].empty?
+    false
   end
 
-  class << self
-    def perform
-      create_assignments! all_repos
-    end
-
-    def quick_refresh
-      create_assignments! latest_repos
-    end
-
-    def refresh
-      perform
-    end
-
-    def create_assignments!(repos)
-      repos.each do |repo_url|
-        match = repo_url.match(USERNAME)
-        break if match.nil?
-        github_username = match[1]
-        Fact.append!("#{repo_url}:changedlogd", "github:#{github_username}", "Repo featured on Changelogd", Time.now, repo_url, ['repo', 'changedlog'])
-      end
-    end
-
-    def latest_repos
-      repos_in(API_URI).flatten.uniq
-    end
-
-    def all_repos
-      repos = []
-      (1...20).each do |time|
-        start = ((time * 50) + 1) - 50
-        repos << repos_in(API_URI + "?start=#{start}&num=50")
-      end
-      repos.flatten.uniq
-    end
-
-    def repos_in(url)
-      res = Servant.get(url)
-      doc = Nokogiri::HTML(res.to_s)
-      doc.xpath('//post/link-description').collect do |element|
-        element.content.scan(REPO)
-      end
-    end
-  end
 end

--- a/lib/tasks/facts.rake
+++ b/lib/tasks/facts.rake
@@ -1,8 +1,6 @@
 namespace :facts do
   # PRODUCTION: RUNS DAILY
   task system: :environment do
-    puts "Changelogd"
-    Changelogd.refresh
     puts "Ashcat"
     Ashcat.perform
   end

--- a/spec/models/badges/changelogd_spec.rb
+++ b/spec/models/badges/changelogd_spec.rb
@@ -1,40 +1,13 @@
 require 'spec_helper'
 
-RSpec.describe Changelogd, type: :model, skip: true do
-  it 'should award a user if there is a tag' do
-    stub_request(:get, Changelogd::API_URI).to_return(body: File.read(File.join(Rails.root, 'spec', 'fixtures', 'changelogd_feed.xml')))
-    Changelogd.quick_refresh
-
-    user = Fabricate(:user, github: 'CloudMade')
-
-    changelogd = Changelogd.new(user)
-    expect(changelogd.award?).to eq(true)
-    expect(changelogd.reasons[:links].first['Leaflet']).to eq('http://github.com/CloudMade/Leaflet')
-  end
-
+RSpec.describe Changelogd, type: :model do
   it 'should have a name and description' do
     expect(Changelogd.name).not_to be_blank
     expect(Changelogd.description).not_to be_blank
   end
 
-  it 'should should find github projects' do
-    stub_request(:get, Changelogd::API_URI).to_return(body: File.read(File.join(Rails.root, 'spec', 'fixtures', 'changelogd_feed.xml')))
-    expect(Changelogd.latest_repos.first).to eq('http://github.com/CloudMade/Leaflet')
-  end
-
-  it 'should create a fact' do
-    stub_request(:get, Changelogd::API_URI).to_return(body: File.read(File.join(Rails.root, 'spec', 'fixtures', 'changelogd_feed.xml')))
-    Changelogd.quick_refresh
-    fact = Fact.where(identity: 'http://github.com/CloudMade/Leaflet:changedlogd').first
-    expect(fact).not_to be_nil
-  end
-
-  it 'should find the first and last project', functional: true, slow: true, skip: 'resource not found' do
-    expect(Changelogd.all_repos).to include('http://github.com/kennethreitz/tablib')
-    expect(Changelogd.all_repos).to include('http://github.com/johnsheehan/RestSharp')
-  end
-
-  it 'should find repos in episodes too', functional: true, skip: 'resource not found' do
-    expect(Changelogd.all_repos).to include('https://github.com/geemus/excon')
+  it 'is not awardable' do
+    user = Fabricate(:user, github: 'codebender')
+    expect(Changelogd.new(user).award?).to be false
   end
 end


### PR DESCRIPTION
[Remove the ChangeLog API integration](https://assembly.com/coderwall/bounties/488)
---
- remove existing api integration
- support existing badges