### PR TITLE
move db query from view to controller and method

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,6 +1,7 @@
 class AdminController < BaseAdminController
 
   def index
+    @networks = Network.where('protips_count_cache > 0').order('protips_count_cache desc')
   end
 
   def teams

--- a/app/models/network.rb
+++ b/app/models/network.rb
@@ -96,7 +96,7 @@ class Network < ActiveRecord::Base
 
   def tag_with_name!
     unless self.tag_list.include? self.name
-      self.tag_list = (self.tag_list + [self.name, self.slug])
+      self.tag_list.add(self.slug)
     end
   end
 
@@ -238,6 +238,10 @@ class Network < ActiveRecord::Base
     Skill.where(name: self.tag_list).select('DISTINCT(user_id)').map(&:user).each do |member|
       member.join(self)
     end
+  end
+
+  def recent_protips_count
+    self.protips.where('protips.created_at > ?', 1.week.ago).count
   end
 
 end

--- a/app/views/admin/index.html.slim
+++ b/app/views/admin/index.html.slim
@@ -71,10 +71,10 @@
       h4 Pro tips created in networks in past week
     section
       ul.networks
-        -Network.where('protips_count_cache > 0').order('protips_count_cache desc').each do |network|
+        -@networks.each do |network|
           li.network
             span.name= link_to network.name, network_path(network)
-            span.created_at= network.protips.where('created_at > ?', 1.week.ago).count
+            span.created_at= network.recent_protips_count
 
   .widget.orange
     header

--- a/spec/controllers/networks_controller_spec.rb
+++ b/spec/controllers/networks_controller_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe NetworksController, type: :controller do
+  let(:current_user) { Fabricate(:user, admin: true) }
+
+  before { controller.send :sign_in, current_user }
+
+  def valid_attributes
+    {
+      name: 'python'
+    }
+  end
+
+  def valid_session
+    {}
+  end
+
+  describe 'Create network' do
+    describe 'with valid attributes' do
+      it 'creates a network and adds to tags' do
+        expect do
+          post :create, { network: valid_attributes}, valid_session
+        end.to change(Tag, :count).by(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Move database query from views to `admin_controller` and `network` model respectively.