### PR TITLE
[FIX] Run pretty json only when realy relevant, e.g. debug mode on !515

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -50,7 +50,7 @@ module SearchModule
         # Eval ? Really ?
         eval(facets.to_tire) unless facets.nil?
 
-        Rails.logger.debug ("[search](#{context.to_s}):" + JSON.pretty_generate(to_hash))
+        Rails.logger.debug { "[search](#{context.to_s}):" + JSON.pretty_generate(to_hash) }
       end
     rescue Tire::Search::SearchRequestFailed, Errno::ECONNREFUSED
       if @options[:failover].nil?


### PR DESCRIPTION
I'm still setting up the environment, however it's clear that n production, the actual stack stem from the generate_json call:
````
/vendor/ruby-2.1.5/lib/ruby/2.1.0/json/common.rb:285 in "pretty_generate"
/app/models/search.rb:53 in "block in execute"
/vendor/bundle/ruby/2.1.0/gems/tire-0.6.2/lib/tire/model/search.rb:97 in "instance_eval"
/vendor/bundle/ruby/2.1.0/gems/tire-0.6.2/lib/tire/model/search.rb:97 in "search"
/app/models/search.rb:31 in "execute"
/app/controllers/protips_controller.rb:375 in "search"
/app/controllers/protips_controller.rb:23 in "index"
````

Changing the log line to block makes a more efficient call (e.g. when not in debug level, line is not being executed) with the extra benefit that if the issue is only in this printing line, it will no longer occur.
that being said, I haven't being able to verify that. yet.