### PR TITLE
Fixed opportunity search error on unescaped regex special characters **#525**

### DIFF
--- a/app/controllers/opportunities_controller.rb
+++ b/app/controllers/opportunities_controller.rb
@@ -166,6 +166,8 @@ class OpportunitiesController < ApplicationController
   def get_jobs_for(chosen_location, tag, page, query = nil, remote_allowed = false)
     scope = Opportunity
 
+    escaped_query = query.nil? ? query : Regexp.escape(query)
+
     if remote_allowed
       scope = scope.where(remote: true)
     else
@@ -173,7 +175,7 @@ class OpportunitiesController < ApplicationController
     end
 
     scope = scope.by_tag(tag) unless tag.nil?
-    scope = scope.by_query(query) if query
+    scope = scope.by_query(escaped_query) if escaped_query
     # TODO: Verify that there are no unmigrated teams
     scope = scope.where('team_id is not null')
     scope.offset((page-1) * 20)

--- a/spec/controllers/opportunity_controlller_spec.rb
+++ b/spec/controllers/opportunity_controlller_spec.rb
@@ -46,6 +46,17 @@ RSpec.describe OpportunitiesController, type: :controller do
           expect(assigns(:jobs)).to_not be_include(@opportunity2)
         end
       end
+
+      context "by query with keywords containing regexp special characters" do
+        it "should NOT fail when querying with keywords containing '+'" do
+          get :index, location: nil, q: 'C++'
+          expect(assigns(:jobs))
+        end
+        it "should NOT fail when querying with keywords containing '.^$*+?()[{\|'" do
+          get :index, location: nil, q: 'java .^$*+?()[{\|'
+          expect(assigns(:jobs))
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Escape the query string before executing the opportunity search.
Added relevant test cases to the opportunity controller spec.