### PR TITLE
Bug fix: Redirect to settings page after linking acct **#521**

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -27,7 +27,7 @@ class SessionsController < ApplicationController
       current_user.apply_oauth(oauth)
       current_user.save!
       flash[:notice] = "#{oauth[:provider].humanize} account linked"
-      redirect_to(destination_url)
+      redirect_to(edit_user_url(current_user))
     else
       @user = User.find_with_oauth(oauth)
       if @user && !@user.new_record?

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,4 +36,28 @@ Coderwall::Application.configure do
   BetterErrors::Middleware.allow_ip! ENV['TRUSTED_IP'] if ENV['TRUSTED_IP']
   #Rails.logger = Logger.new(STDOUT)
   #Rails.logger.level = Logger::DEBUG
+
+  # Mock account credentials
+  OmniAuth.config.test_mode = true
+  OmniAuth.config.mock_auth[:linkedin] = OmniAuth::AuthHash.new({
+    :provider => 'linkedin',
+    :uid => 'linkedin12345',
+    :info => {:nickname => 'linkedinuser'},
+    :credentials => {
+      :token => 'linkedin1',
+      :secret => 'secret'}})
+  OmniAuth.config.mock_auth[:twitter] = OmniAuth::AuthHash.new({
+    :provider => 'twitter', 
+    :uid => 'twitter123545', 
+    :info => {:nickname => 'twitteruser'}, 
+    :credentials => {
+      :token => 'twitter1', 
+      :secret => 'secret'}})
+  OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new({
+    :provider => 'github', 
+    :uid => 'github123545', 
+    :info => {:nickname => 'githubuser'}, 
+    :credentials => {
+      :token => 'github1', 
+      :secret => 'secret'}})
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -106,12 +106,12 @@ RSpec.describe SessionsController, type: :controller, skip: true do
       expect(response).to redirect_to(new_user_url)
     end
 
-    it 'redirects back to profile page if user is already signed in' do
+    it 'redirects back to settings page if user is already signed in' do
       sign_in(user = Fabricate(:user, username: 'darth'))
       request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:github] = github_response
       get :create
       expect(flash[:notice]).to include('linked')
-      expect(response).to redirect_to(badge_url(username: 'darth'))
+      expect(response).to redirect_to(edit_user_url(controller.send :current_user))
     end
   end
 
@@ -201,6 +201,15 @@ RSpec.describe SessionsController, type: :controller, skip: true do
       request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:twitter] = twitter_response
       get :create
       expect(flash[:error]).to include('already associated with a different member')
+    end
+
+    it 'successful linking of an account should redirect to settings page' do
+      user = Fabricate(:user, twitter: 'mdeiters', twitter_id: '6271932')
+      sign_in(user)
+      request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:twitter] = twitter_response
+      get :create
+      expect(flash[:notice]).to include('linked')
+      expect(response).to redirect_to(edit_user_url(controller.send :current_user))
     end
   end
 


### PR DESCRIPTION
Bug fix for bounty 521: 
- Redirect to settings page rather than home page, after linking a Twitter/GitHub/LinkedIn account
- Added test case for fix
- Added OmniAuth mock credentials for testing the fix through a browser