### PR TITLE
Fix a bug with white on white text in account nav

### DIFF
--- a/app/assets/stylesheets/coderwall.scss
+++ b/app/assets/stylesheets/coderwall.scss
@@ -2117,6 +2117,11 @@ input[type=file].safari5-upload-hack {
   font-weight: normal;
 }
 
+/* Bug fix for white on white text in user nav dropdown  */
+.jq-dropdown-panel {
+    background-color: #343131 !important;
+}
+
 /* ------------------------------------  */
 /* START OF UGLY BROWSER-SPECIFIC HACKS */
 /* ----------------------------------  */


### PR DESCRIPTION
Hopefully I did it right this time :smiley: 

![capturfiles_3](https://cloud.githubusercontent.com/assets/1480063/7508374/022eea6c-f434-11e4-99b8-b44c22606a38.png)

A very naive fix is this CSS hack:

```css
.jq-dropdown-panel{
    background-color: #343131;
}
```

Which looks like this:

![capturfiles_4](https://cloud.githubusercontent.com/assets/1480063/7508391/3ea68dd8-f434-11e4-8ba8-f59986fbfb07.png)
