### PR TITLE
proposed fix for comment bug

### DIFF
--- a/lib/cfm.rb
+++ b/lib/cfm.rb
@@ -26,6 +26,9 @@ module CFM
 
       def add_nofollow( html)
         #redcarpet isn't adding nofollow like it is suppose to.
+       if html.match(/rel=["']nofollow["']/)
+         return html
+       end
        html.scan(/(\<a href=["'].*?["']\>.*?\<\/a\>)/).flatten.each do |link|
          if link.match(/\<a href=["'](http:\/\/|www){0,1}((coderwall.com)(\/.*?){0,1}|\/.*?)["']\>(.*?)\<\/a\>/)
           else

--- a/spec/helpers/protips_helper_spec.rb
+++ b/spec/helpers/protips_helper_spec.rb
@@ -40,6 +40,16 @@ RSpec.describe ProtipsHelper, type: :helper do
         expect(helper.users_background_image).to be_nil
       end
     end
+
+    describe "comments" do
+      context "has comments" do
+        it "renders comment links correctly" do
+          expect(formatted_comment("http://www.google.com")).to eq "<p><a href=\"http://www.google.com\" rel=\"nofollow\">http://www.google.com</a></p>\n"
+        end
+      end
+    end
+
+
   end
 
 end


### PR DESCRIPTION
noticed that links are currently broken on the site, the function in lib/comments that processes links appears to have been patched to compensate for redcloth not adding nofollow links, but they're being added now, added a test spec to check it's working right
